### PR TITLE
addressing issue 70

### DIFF
--- a/src/physical_constants.jl
+++ b/src/physical_constants.jl
@@ -48,14 +48,6 @@ __b_N_avogadro = 6.02214076e23
 
 
 
-
-
-
-
-
-
-
-
 __b_mu_deuteron = 4.330735087e-27
 # deuteron magnetic moment in [eV/T]
 __b_mu_electron = -9.2847646917e-24
@@ -76,12 +68,6 @@ __b_mu_triton = 1.5046095178e-26
 
 
 
-
-
-
-
-
-
 # values calculated from other constants in this collection
 
 
@@ -96,15 +82,6 @@ __b_h_bar_planck = __b_h_planck / 2pi;
 # h_planck/twopi [eV*sec]
 __b_eps_0_vac = 8.8541878188e-12
 # Permittivity of free space in [F/m]
-
-
-
-
-
-
-
-
-
 
 
 

--- a/src/species_initialize.jl
+++ b/src/species_initialize.jl
@@ -43,11 +43,18 @@ of information specifice to the chosen particle.
 # Fields:
 1. `name::String': 	the name of the particle 
 2. `charge::Int32': the net charge of the particle in units of |e|
+										- bookkeeping only, thus in internal units
+										- use the 'charge()' function to get the charge 
+										- in the desired units
 3. `mass::Float64': the mass of the particle
-4. `spin::Float64': the spin of the particle (multiplied with ħ)
-5. `mu::Float64': 	the magnetic moment of the particle.
+										- bookkeeping only, thus in internal units
+										- use the 'mass()' function to get the charge 
+										- in the desired units
+4. `spin::Float64': the spin of the particle in eV⋅s 
+										- (half/integer multiplied with ħ)
+5. `mu::Float64': 	the magnetic moment of the particle in eV/T.
 5. `iso::Int': 			if the particle is an atomic isotope, this is the 
-										mass number, otherwise 0
+										mass number, otherwise -1
 
 The Species Struct also has a constructor called Species, 
 documentation for which follows.
@@ -60,7 +67,7 @@ If an anti-particle (subatomic or otherwise) prepend "anti-" to the name.
 # Arguments
 1. `name::String': the name of the species 
 		* subatomic particle names must be given exactly,
-		* Atomic symbols may include charge and isotope eg Li#9+1
+		* Atomic symbols may include charge and isotope eg #9Li+1
 		* where #[1-999] specifies the isotope and (+/-)[0-999] specifies charge
 2. `charge::Int=0': the charge of the particle.
 		* only affects atoms 


### PR DESCRIPTION
Added doc to species struct about bookkeeping units, 
edited (doc) to show default iso = -1