### PR TITLE
Getprop override

### DIFF
--- a/src/APCdef.jl
+++ b/src/APCdef.jl
@@ -189,23 +189,23 @@ macro APCdef(kwargs...)
       #massof and charge of
       function $(esc(:massof))(species::Species)::$masstype
         @assert species.kind != Kind.NULL "Can't call massof() on a null Species object"
-        return uconvert($mass_unit, species.mass)
+        return uconvert($mass_unit, getfield(species, :mass))
       end
       function $(esc(:chargeof))(species::Species)::$chargetype
         @assert species.kind != Kind.NULL "Can't call chargeof() on a null Species object"
-        return uconvert($charge_unit, species.charge)
+        return uconvert($charge_unit, getfield(species, :charge))
       end
 
       #added options for string input
       function $(esc(:massof))(speciesname::String)::$masstype
         species = Species(speciesname)
         @assert species.kind != Kind.NULL "Can't call massof() on a null Species object"
-        return uconvert($mass_unit, species.mass)
+        return uconvert($mass_unit, getfield(species, :mass))
       end
       function $(esc(:chargeof))(speciesname::String)::$chargetype
         species = Species(speciesname)
         @assert species.kind != Kind.NULL "Can't call chargeof() on a null Species object"
-        return uconvert($charge_unit, species.charge)
+        return uconvert($charge_unit, getfield(species, :charge))
       end
 
       # define the named tuple that contains all the constants

--- a/src/APCdef.jl
+++ b/src/APCdef.jl
@@ -188,23 +188,23 @@ macro APCdef(kwargs...)
     return quote
       #massof and charge of
       function $(esc(:massof))(species::Species)::$masstype
-        @assert species.kind != Kind.NULL "Can't call massof() on a null Species object"
+        @assert getfield(species, :kind) != Kind.NULL "Can't call massof() on a null Species object"
         return uconvert($mass_unit, getfield(species, :mass))
       end
       function $(esc(:chargeof))(species::Species)::$chargetype
-        @assert species.kind != Kind.NULL "Can't call chargeof() on a null Species object"
+        @assert getfield(species, :kind) != Kind.NULL "Can't call chargeof() on a null Species object"
         return uconvert($charge_unit, getfield(species, :charge))
       end
 
       #added options for string input
       function $(esc(:massof))(speciesname::String)::$masstype
         species = Species(speciesname)
-        @assert species.kind != Kind.NULL "Can't call massof() on a null Species object"
+        @assert getfield(species, :kind) != Kind.NULL "Can't call massof() on a null Species object"
         return uconvert($mass_unit, getfield(species, :mass))
       end
       function $(esc(:chargeof))(speciesname::String)::$chargetype
         species = Species(speciesname)
-        @assert species.kind != Kind.NULL "Can't call chargeof() on a null Species object"
+        @assert getfield(species, :kind) != Kind.NULL "Can't call chargeof() on a null Species object"
         return uconvert($charge_unit, getfield(species, :charge))
       end
 
@@ -230,24 +230,24 @@ macro APCdef(kwargs...)
     return quote
       #massof and charge of
       function $(esc(:massof))(species::Species)::Float64
-        @assert species.kind != Kind.NULL "Can't call massof() on a null Species object"
-        return uconvert($mass_unit, species.mass).val
+        @assert getfield(species, :kind) != Kind.NULL "Can't call massof() on a null Species object"
+        return uconvert($mass_unit, getfield(species, :mass)).val
       end
       function $(esc(:chargeof))(species::Species)::Float64
-        @assert species.kind != Kind.NULL "Can't call chargeof() on a null Species object"
-        return uconvert($charge_unit, species.charge).val
+        @assert getfield(species, :kind) != Kind.NULL "Can't call chargeof() on a null Species object"
+        return uconvert($charge_unit, getfield(species, :charge)).val
       end
 
       #added options for string input
       function $(esc(:massof))(speciesname::String)::Float64
         species = Species(speciesname)
-        @assert species.kind != Kind.NULL "Can't call massof() on a null Species object"
-        return uconvert($mass_unit, species.mass).val
+        @assert getfield(species, :kind) != Kind.NULL "Can't call massof() on a null Species object"
+        return uconvert($mass_unit, getfield(species, :mass)).val
       end
       function $(esc(:chargeof))(speciesname::String)::Float64
         species = Species(speciesname)
-        @assert species.kind != Kind.NULL "Can't call chargeof() on a null Species object"
-        return uconvert($charge_unit, species.charge).val
+        @assert getfield(species, :kind) != Kind.NULL "Can't call chargeof() on a null Species object"
+        return uconvert($charge_unit, getfield(species, :charge)).val
       end
       # define the named tuple that contains all the constants
       $(esc(name)) = NamedTuple{Tuple(keys($constantsdict_float))}(values($constantsdict_float))
@@ -272,23 +272,23 @@ macro APCdef(kwargs...)
     return quote
       #massof and charge of
       function $(esc(:massof))(species::Species)::DynamicQuantities.Quantity
-        @assert species.kind != Kind.NULL "Can't call massof() on a null Species object"
-        return convert(DynamicQuantities.Quantity, uconvert($mass_unit, species.mass))
+        @assert getfield(species, :kind) != Kind.NULL "Can't call massof() on a null Species object"
+        return convert(DynamicQuantities.Quantity, uconvert($mass_unit, getfield(species, :mass)))
       end
       function $(esc(:chargeof))(species::Species)::DynamicQuantities.Quantity
-        @assert species.kind != Kind.NULL "Can't call chargeof() on a null Species object"
-        return convert(DynamicQuantities.Quantity, uconvert($charge_unit, species.charge))
+        @assert getfield(species, :kind) != Kind.NULL "Can't call chargeof() on a null Species object"
+        return convert(DynamicQuantities.Quantity, uconvert($charge_unit, getfield(species, :charge)))
       end
       #added options for string input
       function $(esc(:massof))(speciesname::String)::DynamicQuantities.Quantity
         species = Species(speciesname)
-        @assert species.kind != Kind.NULL "Can't call massof() on a null Species object"
-        return convert(DynamicQuantities.Quantity, uconvert($mass_unit, species.mass))
+        @assert getfield(species, :kind) != Kind.NULL "Can't call massof() on a null Species object"
+        return convert(DynamicQuantities.Quantity, uconvert($mass_unit, getfield(species, :mass)))
       end
       function $(esc(:chargeof))(speciesname::String)::DynamicQuantities.Quantity
         species = Species(speciesname)
-        @assert species.kind != Kind.NULL "Can't call chargeof() on a null Species object"
-        return convert(DynamicQuantities.Quantity, uconvert($charge_unit, species.charge))
+        @assert getfield(species, :kind) != Kind.NULL "Can't call chargeof() on a null Species object"
+        return convert(DynamicQuantities.Quantity, uconvert($charge_unit, getfield(species, :charge)))
       end
       # define the named tuple that contains all the constants
       $(esc(name)) = NamedTuple{Tuple(keys($constantsdict_dynamicquantities))}(values($constantsdict_dynamicquantities))

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -331,3 +331,17 @@ end
 # In the following code, standard base.getproperty functions are 
 # overridden
 #####################################################################
+"""
+This definition overrides Base.getproperty to disallow access to 
+the Species fields :mass and :charge via the dot syntax, i.e. 
+Species.mass or Species.charge"
+"""
+Base.getproperty
+
+function Base.getproperty(obj::Species, field::Symbol)
+  if field == :mass || field == :charge
+    error("Do not use the 'base.getproperty' syntax to access fields 
+    of Species objects: instead use the provided functions; massof,
+    and chargeof.")
+  end
+end

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -325,3 +325,9 @@ function create_atomic_species(name::String, charge::Int, iso::Int)
   end
 
 end
+
+
+#####################################################################
+# In the following code, standard base.getproperty functions are 
+# overridden
+#####################################################################

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -9,10 +9,10 @@ Get the atomic number (positive nuclear charge) of a tracked particle.
 atomicnumber
 
 function atomicnumber(particle::Species)
-  if haskey(ATOMIC_SPECIES, particle.name)
-    return ATOMIC_SPECIES[particle.name].Z
+  if haskey(ATOMIC_SPECIES, getfield(particle, :name))
+    return ATOMIC_SPECIES[getfield(particle, :name)].Z
   else
-    print(f"{particle.name} is not an atom, and thus no atomic number.")
+    print("$(getfield(particle, :name)) is not an atom, and thus no atomic number.")
     return
   end
 end;
@@ -29,7 +29,7 @@ For atomic particles, will currently return 0. Will be updated in a future patch
 """
 
 function g_spin(species::Species)
-  return 2 * species.mass * species.moment / (species.spin * species.charge)
+  return 2 * getfield(species, :mass) * getfield(species, :moment) / (getfield(species, :spin) * getfield(species, :charge))
 end;
 
 
@@ -61,11 +61,12 @@ Compute and deliver the gyromagnetic anomaly for a baryon given its g factor
 g_nucleon
 
 function g_nucleon(species::Species)
-  Z = species.charge
-  m = species.mass
+  Z = getfield(species, :charge).val
+  m = getfield(species, :mass).val
   gs = g_spin(species)
+  m_p = getfield(Species("proton"), :mass).val
 
-  return gs * Z * __b_m_proton.val / m
+  return gs * Z * m_p / m
 end;
 
 
@@ -83,23 +84,23 @@ full_name
 
 
 function full_name(species::Species)
-  if haskey(SUBATOMIC_SPECIES, species.name)
-    return species.name
+  if haskey(SUBATOMIC_SPECIES, getfield(species, :name))
+    return getfield(species, :name)
   else
     isostring = ""
     chargestring = ""
     if species.iso > 0
-      isostring = "#" * f"{convert(Int64, species.iso)}"
+      isostring = "#" * "$(convert(Int64, species.iso))"
     end
-    if species.charge.val != 0
-      if species.charge.val < 0
-        chargestring = f"-{convert(Int64, abs(species.charge.val))}"
-      elseif species.charge.val > 0
-        chargestring = f"+{convert(Int64, abs(species.charge.val))}"
+    if getfield(species, :charge).val != 0
+      if getfield(species, :charge).val < 0
+        chargestring = "-$(convert(Int64, abs(species.charge.val)))"
+      elseif getfield(species, :charge).val > 0
+        chargestring = "+$(convert(Int64, abs(species.charge.val)))"
 
       end
     end
-    return isostring * species.name * chargestring
+    return isostring * getfield(species, :name) * chargestring
   end
 end;
 

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -94,9 +94,9 @@ function full_name(species::Species)
     end
     if getfield(species, :charge).val != 0
       if getfield(species, :charge).val < 0
-        chargestring = "-$(convert(Int64, abs(species.charge.val)))"
+        chargestring = "-$(convert(Int64, abs(getfield(species, :charge).val)))"
       elseif getfield(species, :charge).val > 0
-        chargestring = "+$(convert(Int64, abs(species.charge.val)))"
+        chargestring = "+$(convert(Int64, abs(getfield(species, :charge).val)))"
 
       end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,7 +84,7 @@ end
   @test getfield(Species("¹⁸O"), :iso) == 18
   @test getfield(Species("²³Na"), :iso) == 23
   @test getfield(Species("²⁴Mg"), :iso) == 24
-  @test getfield(pecies("²⁵Mg"), :iso) == 25
+  @test getfield(Species("²⁵Mg"), :iso) == 25
   @test getfield(Species("²⁶Mg"), :iso) == 26
   @test getfield(Species("²⁷Al"), :iso) == 27
   @test getfield(Species("²³⁵U"), :iso) == 235

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,50 +47,50 @@ end
   @test chargeof(Species("He")) ≈ 0
 
   #test isotope numbers
-  @test getfield(Species("#1H"), iso) == 1
-  @test getfield(Species("H"), iso) == -1
-  @test getfield(Species("#13C"), iso) == 13
-  @test getfield(Species("C"), iso) == -1
-  @test getfield(Species("#16O"), iso) == 16
-  @test getfield(Species("O"), iso) == -1
-  @test getfield(Species("#56Fe"), iso) == 56
-  @test getfield(Species("Fe"), iso) == -1
-  @test getfield(Species("#7Li"), iso) == 7
-  @test getfield(Species("Li"), iso) == -1
-  @test getfield(Species("#14N"), iso) == 14
-  @test getfield(Species("N"), iso) == -1
-  @test getfield(Species("#27Al"), iso) == 27
-  @test getfield(Species("Al"), iso) == -1
-  @test getfield(Species("#24Mg"), iso) == 24
-  @test getfield(Species("Mg"), iso) == -1
-  @test getfield(Species("#235U"), iso) == 235
-  @test getfield(Species("#236U"), iso) == 236
-  @test getfield(Species("U"), iso) == -1
+  @test getfield(Species("#1H"), :iso) == 1
+  @test getfield(Species("H"), :iso) == -1
+  @test getfield(Species("#13C"), :iso) == 13
+  @test getfield(Species("C"), :iso) == -1
+  @test getfield(Species("#16O"), :iso) == 16
+  @test getfield(Species("O"), :iso) == -1
+  @test getfield(Species("#56Fe"), :iso) == 56
+  @test getfield(Species("Fe"), :iso) == -1
+  @test getfield(Species("#7Li"), :iso) == 7
+  @test getfield(Species("Li"), :iso) == -1
+  @test getfield(Species("#14N"), :iso) == 14
+  @test getfield(Species("N"), :iso) == -1
+  @test getfield(Species("#27Al"), :iso) == 27
+  @test getfield(Species("Al"), :iso) == -1
+  @test getfield(Species("#24Mg"), :iso) == 24
+  @test getfield(Species("Mg"), :iso) == -1
+  @test getfield(Species("#235U"), :iso) == 235
+  @test getfield(Species("#236U"), :iso) == 236
+  @test getfield(Species("U"), :iso) == -1
 
   #test isotope number with superscript
-  @test getfield(Species("¹H"), iso) == 1
-  @test getfield(Species("²H"), iso) == 2
-  @test getfield(Species("³H"), iso) == 3
-  @test getfield(Species("⁴He"), iso) == 4
-  @test getfield(Species("⁵He"), iso) == 5
-  @test getfield(Species("⁶Li"), iso) == 6
-  @test getfield(Species("⁷Li"), iso) == 7
-  @test getfield(Species("⁸Be"), iso) == 8
-  @test getfield(Species("⁹Be"), iso) == 9
-  @test getfield(Species("¹⁴N"), iso) == 14
-  @test getfield(Species("¹⁵N"), iso) == 15
-  @test getfield(Species("¹⁶O"), iso) == 16
-  @test getfield(Species("¹⁷O"), iso) == 17
-  @test getfield(Species("¹⁸O"), iso) == 18
-  @test getfield(Species("²³Na"), iso) == 23
-  @test getfield(Species("²⁴Mg"), iso) == 24
-  @test getfield(pecies("²⁵Mg"), iso) == 25
-  @test getfield(Species("²⁶Mg"), iso) == 26
-  @test getfield(Species("²⁷Al"), iso) == 27
-  @test getfield(Species("²³⁵U"), iso) == 235
-  @test getfield(Species("²³⁶U"), iso) == 236
-  @test getfield(Species("²³⁸U"), iso) == 238
-  @test getfield(Species("U"), iso) == -1
+  @test getfield(Species("¹H"), :iso) == 1
+  @test getfield(Species("²H"), :iso) == 2
+  @test getfield(Species("³H"), :iso) == 3
+  @test getfield(Species("⁴He"), :iso) == 4
+  @test getfield(Species("⁵He"), :iso) == 5
+  @test getfield(Species("⁶Li"), :iso) == 6
+  @test getfield(Species("⁷Li"), :iso) == 7
+  @test getfield(Species("⁸Be"), :iso) == 8
+  @test getfield(Species("⁹Be"), :iso) == 9
+  @test getfield(Species("¹⁴N"), :iso) == 14
+  @test getfield(Species("¹⁵N"), :iso) == 15
+  @test getfield(Species("¹⁶O"), :iso) == 16
+  @test getfield(Species("¹⁷O"), :iso) == 17
+  @test getfield(Species("¹⁸O"), :iso) == 18
+  @test getfield(Species("²³Na"), :iso) == 23
+  @test getfield(Species("²⁴Mg"), :iso) == 24
+  @test getfield(pecies("²⁵Mg"), :iso) == 25
+  @test getfield(Species("²⁶Mg"), :iso) == 26
+  @test getfield(Species("²⁷Al"), :iso) == 27
+  @test getfield(Species("²³⁵U"), :iso) == 235
+  @test getfield(Species("²³⁶U"), :iso) == 236
+  @test getfield(Species("²³⁸U"), :iso) == 238
+  @test getfield(Species("U"), :iso) == -1
 end
 
 @testset "test Species parsing" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,50 +47,50 @@ end
   @test chargeof(Species("He")) ≈ 0
 
   #test isotope numbers
-  @test Species("#1H").iso == 1
-  @test Species("H").iso == -1
-  @test Species("#13C").iso == 13
-  @test Species("C").iso == -1
-  @test Species("#16O").iso == 16
-  @test Species("O").iso == -1
-  @test Species("#56Fe").iso == 56
-  @test Species("Fe").iso == -1
-  @test Species("#7Li").iso == 7
-  @test Species("Li").iso == -1
-  @test Species("#14N").iso == 14
-  @test Species("N").iso == -1
-  @test Species("#27Al").iso == 27
-  @test Species("Al").iso == -1
-  @test Species("#24Mg").iso == 24
-  @test Species("Mg").iso == -1
-  @test Species("#235U").iso == 235
-  @test Species("#236U").iso == 236
-  @test Species("U").iso == -1
+  @test getfield(Species("#1H"), iso) == 1
+  @test getfield(Species("H"), iso) == -1
+  @test getfield(Species("#13C"), iso) == 13
+  @test getfield(Species("C"), iso) == -1
+  @test getfield(Species("#16O"), iso) == 16
+  @test getfield(Species("O"), iso) == -1
+  @test getfield(Species("#56Fe"), iso) == 56
+  @test getfield(Species("Fe"), iso) == -1
+  @test getfield(Species("#7Li"), iso) == 7
+  @test getfield(Species("Li"), iso) == -1
+  @test getfield(Species("#14N"), iso) == 14
+  @test getfield(Species("N"), iso) == -1
+  @test getfield(Species("#27Al"), iso) == 27
+  @test getfield(Species("Al"), iso) == -1
+  @test getfield(Species("#24Mg"), iso) == 24
+  @test getfield(Species("Mg"), iso) == -1
+  @test getfield(Species("#235U"), iso) == 235
+  @test getfield(Species("#236U"), iso) == 236
+  @test getfield(Species("U"), iso) == -1
 
   #test isotope number with superscript
-  @test Species("¹H").iso == 1
-  @test Species("²H").iso == 2
-  @test Species("³H").iso == 3
-  @test Species("⁴He").iso == 4
-  @test Species("⁵He").iso == 5
-  @test Species("⁶Li").iso == 6
-  @test Species("⁷Li").iso == 7
-  @test Species("⁸Be").iso == 8
-  @test Species("⁹Be").iso == 9
-  @test Species("¹⁴N").iso == 14
-  @test Species("¹⁵N").iso == 15
-  @test Species("¹⁶O").iso == 16
-  @test Species("¹⁷O").iso == 17
-  @test Species("¹⁸O").iso == 18
-  @test Species("²³Na").iso == 23
-  @test Species("²⁴Mg").iso == 24
-  @test Species("²⁵Mg").iso == 25
-  @test Species("²⁶Mg").iso == 26
-  @test Species("²⁷Al").iso == 27
-  @test Species("²³⁵U").iso == 235
-  @test Species("²³⁶U").iso == 236
-  @test Species("²³⁸U").iso == 238
-  @test Species("U").iso == -1
+  @test getfield(Species("¹H"), iso) == 1
+  @test getfield(Species("²H"), iso) == 2
+  @test getfield(Species("³H"), iso) == 3
+  @test getfield(Species("⁴He"), iso) == 4
+  @test getfield(Species("⁵He"), iso) == 5
+  @test getfield(Species("⁶Li"), iso) == 6
+  @test getfield(Species("⁷Li"), iso) == 7
+  @test getfield(Species("⁸Be"), iso) == 8
+  @test getfield(Species("⁹Be"), iso) == 9
+  @test getfield(Species("¹⁴N"), iso) == 14
+  @test getfield(Species("¹⁵N"), iso) == 15
+  @test getfield(Species("¹⁶O"), iso) == 16
+  @test getfield(Species("¹⁷O"), iso) == 17
+  @test getfield(Species("¹⁸O"), iso) == 18
+  @test getfield(Species("²³Na"), iso) == 23
+  @test getfield(Species("²⁴Mg"), iso) == 24
+  @test getfield(pecies("²⁵Mg"), iso) == 25
+  @test getfield(Species("²⁶Mg"), iso) == 26
+  @test getfield(Species("²⁷Al"), iso) == 27
+  @test getfield(Species("²³⁵U"), iso) == 235
+  @test getfield(Species("²³⁶U"), iso) == 236
+  @test getfield(Species("²³⁸U"), iso) == 238
+  @test getfield(Species("U"), iso) == -1
 end
 
 @testset "test Species parsing" begin


### PR DESCRIPTION
I overrode the 'Base.getproperty' function at the bottom of constructors.jl, such that Species.mass and Species.charge throw an educational error.
Additionally, I modified the definitions of massof() and chargeof() to use Core.getfield() instead of Base.getproperty() so they still work.