### PR TITLE
199 gyro consistency

### DIFF
--- a/misc/update_constants.jl
+++ b/misc/update_constants.jl
@@ -34,7 +34,11 @@ CODATA_Consts = Dict{AbstractString,Dict}(
     "elementary charge" => Dict("__b_e_charge" => __b_e_charge),
     "atomic mass unit-kilogram relationship" => Dict("__b_kg_per_amu" => __b_kg_per_amu),
     "atomic mass unit-electron volt relationship" => Dict("__b_eV_per_amu" => __b_eV_per_amu),
-    "electron volt-joule relationship" => Dict("__b_J_per_eV" => __b_J_per_eV)
+    "electron volt-joule relationship" => Dict("__b_J_per_eV" => __b_J_per_eV),
+    "electron mag. mom. anomaly" => Dict("__b_electron_gyro_anom"),
+    "electron magnetic moment anomaly" => Dict("__b_electron_gyro_anom"),
+    "muon mag. mom. anomaly" => Dict("__b_muon_gyro_anom"),
+    "muon magnetic moment anomaly" => Dict("__b_muon_gyro_anom")
 )
 
 

--- a/src/2002_constants.jl
+++ b/src/2002_constants.jl
@@ -102,7 +102,10 @@ const __b_fine_structure = 0.0072973525643
 # fine structure constant
 
 
-
+const __b_electron_gyro_anom = 1.1596521859e-3
+# electron magnetic moment anomaly
+const __b_muon_gyro_anom = 1.16591981e-3
+# muon magnetic moment anomaly
 
 
 

--- a/src/2006_constants.jl
+++ b/src/2006_constants.jl
@@ -102,7 +102,10 @@ const __b_fine_structure = 0.0072973525643
 # fine structure constant
 
 
-
+const __b_electron_gyro_anom = 1.15965218111e-3
+# electron magnetic moment anomaly
+const __b_muon_gyro_anom = 1.16592069e-3
+# muon magnetic moment anomaly
 
 
 

--- a/src/2010_constants.jl
+++ b/src/2010_constants.jl
@@ -102,7 +102,10 @@ const __b_fine_structure = 0.0072973525643
 # fine structure constant
 
 
-
+const __b_electron_gyro_anom = 1.15965218076e-3
+# electron magnetic moment anomaly
+const __b_muon_gyro_anom = 1.16592091e-3
+# muon magnetic moment anomaly
 
 
 

--- a/src/2014_constants.jl
+++ b/src/2014_constants.jl
@@ -108,7 +108,10 @@ const __b_N_avogadro = 6.02214076e23
 const __b_fine_structure = 0.0072973525643
 # fine structure constant
 
-
+const __b_electron_gyro_anom = 1.15965218091e-3
+# electron magnetic moment anomaly
+const __b_muon_gyro_anom = 1.16592089e-3
+# muon magnetic moment anomaly
 
 
 

--- a/src/2018_constants.jl
+++ b/src/2018_constants.jl
@@ -100,7 +100,10 @@ const __b_N_avogadro::Float64 = 6.02214076e23
 const __b_fine_structure::Float64 = 0.0072973525643
 # fine structure constant
 
-
+const __b_electron_gyro_anom = 1.15965218128e-3
+# electron magnetic moment anomaly
+const __b_muon_gyro_anom = 1.16592089e-3
+# muon magnetic moment anomaly
 
 
 

--- a/src/2022_constants.jl
+++ b/src/2022_constants.jl
@@ -109,7 +109,10 @@ const __b_fine_structure = 0.0072973525643
 # fine structure constant
 
 
-
+const __b_electron_gyro_anom = 1.15965218046e-3
+# electron magnetic moment anomaly
+const __b_muon_gyro_anom = 1.16592062e-3
+# muon magnetic moment anomaly
 
 
 

--- a/src/APCdef.jl
+++ b/src/APCdef.jl
@@ -232,7 +232,7 @@ macro APCdef(kwargs...)
         return uconvert($energy_unit * $time_unit, getfield(species, :spin))
       end
 
-      $(esc(:wrapper)) = $wrapper
+      $(esc(:APCconsts)) = $wrapper
 
       $(esc(:UNITS)) = NamedTuple{Tuple(keys($unit_names))}(values($unit_names))
       # define the named tuple that contains all the constants
@@ -291,7 +291,7 @@ macro APCdef(kwargs...)
         return uconvert($energy_unit * $time_unit, getfield(species, :spin)).val
       end
 
-      $(esc(:wrapper)) = $wrapper
+      $(esc(:APCconsts)) = $wrapper
 
       $(esc(:UNITS)) = NamedTuple{Tuple(keys($unit_names))}(values($unit_names))
       # define the named tuple that contains all the constants
@@ -352,7 +352,7 @@ macro APCdef(kwargs...)
         return convert(DynamicQuantities.Quantity, uconvert($spin_unit * $time_unit, getfield(species, spin)))
       end
 
-      $(esc(:wrapper)) = $wrapper
+      $(esc(:APCconsts)) = $wrapper
 
       $(esc(:UNITS)) = NamedTuple{Tuple(keys($unit_names))}(values($unit_names))
       # define the named tuple that contains all the constants

--- a/src/APCdef.jl
+++ b/src/APCdef.jl
@@ -100,7 +100,8 @@ macro APCdef(kwargs...)
   unittype::Symbol = :Float
   unitsystem::NTuple{5,Unitful.FreeUnits} = ACCELERATOR
   name::Symbol = :APC
-
+  wrapper::String = String(name)
+  
 
   # a dictionary that maps the name of the key word variables to their value
   kwargdict::Dict{Symbol,Symbol} = Dict(map(t -> Pair(t.args...), kwargs))
@@ -117,6 +118,7 @@ macro APCdef(kwargs...)
       else
         name = kwargdict[:name]
       end
+      wrapper = String(name)
     else
       @error "$k is not a proper keyword argument for @APCdef, the only options are `unittype`, `unitsystem`, `name`"
       return
@@ -230,6 +232,8 @@ macro APCdef(kwargs...)
         return uconvert($energy_unit * $time_unit, getfield(species, :spin))
       end
 
+      $(esc(:wrapper)) = $wrapper
+
       $(esc(:UNITS)) = NamedTuple{Tuple(keys($unit_names))}(values($unit_names))
       # define the named tuple that contains all the constants
       $(esc(name)) = NamedTuple{Tuple(keys($constantsdict_unitful))}(values($constantsdict_unitful))
@@ -287,9 +291,12 @@ macro APCdef(kwargs...)
         return uconvert($energy_unit * $time_unit, getfield(species, :spin)).val
       end
 
+      $(esc(:wrapper)) = $wrapper
+
       $(esc(:UNITS)) = NamedTuple{Tuple(keys($unit_names))}(values($unit_names))
       # define the named tuple that contains all the constants
       $(esc(name)) = NamedTuple{Tuple(keys($constantsdict_float))}(values($constantsdict_float))
+
       
 
     end
@@ -345,9 +352,12 @@ macro APCdef(kwargs...)
         return convert(DynamicQuantities.Quantity, uconvert($spin_unit * $time_unit, getfield(species, spin)))
       end
 
+      $(esc(:wrapper)) = $wrapper
+
       $(esc(:UNITS)) = NamedTuple{Tuple(keys($unit_names))}(values($unit_names))
       # define the named tuple that contains all the constants
       $(esc(name)) = NamedTuple{Tuple(keys($constantsdict_dynamicquantities))}(values($constantsdict_dynamicquantities))
+
       
 
     end

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -59,16 +59,21 @@ Compute and deliver the gyromagnetic anomaly for a lepton given its g factor
 """ gyromagnetic_anomaly
 
 function gyromagnetic_anomaly(species::Species)
-  vtypes = [Kind.LEPTON, Kind.HADRON]
-  if getfield(species, :name) == "electron" 
-    return parentmodule(@__MODULE__).__MODULE__.__b_electron_gyro_anom
-  elseif getfield(species, :name) == "muon"
-    return parentmodule(@__MODULE__).__MODULE.__b_muon_gyro_anom
-  elseif getfield(species, :kind) ∉ vtypes
-    error("Only subatomic particles have computable gyromagnetic anomalies in this package.")
+
+if isdefined(Main, :wrapper)
+    vtypes = [Kind.LEPTON, Kind.HADRON]
+    if getfield(species, :name) == "electron" 
+      return getfield(Main, Symbol(Main.wrapper)).ELECTRON_GYRO_ANOM
+    elseif getfield(species, :name) == "muon"
+      return getfield(Main, Symbol(Main.wrapper)).MUON_GYRO_ANOM
+    elseif getfield(species, :kind) ∉ vtypes
+      error("Only subatomic particles have computable gyromagnetic anomalies in this package.")
+    else
+      gs = abs(g_spin(species))
+    return (gs - 2) / 2
+    end
   else
-    gs = abs(g_spin(species))
-   return (gs - 2) / 2
+    error("Please run @APCdef before you make a call to gyromagnetic_anomaly")
   end
 end;
 

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -60,12 +60,12 @@ Compute and deliver the gyromagnetic anomaly for a lepton given its g factor
 
 function gyromagnetic_anomaly(species::Species)
 
-if isdefined(Main, :wrapper)
+if isdefined(Main, :APCconsts)
     vtypes = [Kind.LEPTON, Kind.HADRON]
     if getfield(species, :name) == "electron" 
-      return getfield(Main, Symbol(Main.wrapper)).ELECTRON_GYRO_ANOM
+      return getfield(Main, Symbol(Main.APCconsts)).ELECTRON_GYRO_ANOM
     elseif getfield(species, :name) == "muon"
-      return getfield(Main, Symbol(Main.wrapper)).MUON_GYRO_ANOM
+      return getfield(Main, Symbol(Main.APCconsts)).MUON_GYRO_ANOM
     elseif getfield(species, :kind) ∉ vtypes
       error("Only subatomic particles have computable gyromagnetic anomalies in this package.")
     else

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -26,7 +26,7 @@ end;
 
 Compute and return the value of g_s for a particle in [1/(T*s)] == [C/kg]
 For atomic particles, will currently return 0. Will be updated in a future patch
-"""
+""" g_spin
 
 function g_spin(species::Species)
   if isdefined(Main, :UNITS)
@@ -56,16 +56,20 @@ Compute and deliver the gyromagnetic anomaly for a lepton given its g factor
 
 # Arguments:
 1. `gs::Float64': the g_factor for the particle
-"""
-gyromagnetic_anomaly
+""" gyromagnetic_anomaly
 
 function gyromagnetic_anomaly(species::Species)
   vtypes = [Kind.LEPTON, Kind.HADRON]
-  if getfield(species, :kind) ∉ vtypes
+  if getfield(species, :name) == "electron" 
+    return parentmodule(@__MODULE__).__MODULE__.__b_electron_gyro_anom
+  elseif getfield(species, :name) == "muon"
+    return parentmodule(@__MODULE__).__MODULE.__b_muon_gyro_anom
+  elseif getfield(species, :kind) ∉ vtypes
     error("Only subatomic particles have computable gyromagnetic anomalies in this package.")
+  else
+    gs = abs(g_spin(species))
+   return (gs - 2) / 2
   end
-  gs = abs(g_spin(species))
-  return (gs - 2) / 2
 end;
 
 


### PR DESCRIPTION
I added the CODATA values for Electron mag. mom. anomaly and Muon mag. mom. anomaly to each release year, and modified the 'gyromagnetic_anomaly' function to print those values when called on an electron or muon, instead of the typical calculation for other leptons.