### PR TITLE
changed units of __b_h_planck in all releases to increase precision

### DIFF
--- a/src/2002_constants.jl
+++ b/src/2002_constants.jl
@@ -139,8 +139,8 @@ const __b_r_p = __b_r_e * __b_m_electron / __b_m_proton
 # classical proton radius [m]
 const __b_c_light = 2.99792458e8 * u"m/s"
 # speed of light [m/s]
-const __b_h_planck = 4.135667696e-15 * u"eV*s"
-# Planck's constant [eV*s]
+const __b_h_planck = 6.62607015e-34*u"J*s" 
+# Planck's constant [J*s]
 const __b_h_bar_planck = __b_h_planck / 2pi
 # h_planck/twopi [eV*s]
 const __b_classical_radius_factor = __b_r_e * __b_m_electron

--- a/src/2006_constants.jl
+++ b/src/2006_constants.jl
@@ -139,8 +139,8 @@ const __b_r_p = __b_r_e * __b_m_electron / __b_m_proton
 # classical proton radius [m]
 const __b_c_light = 2.99792458e8 * u"m/s"
 # speed of light [m/s]
-const __b_h_planck = 4.135667696e-15 * u"eV*s"
-# Planck's constant [eV*s]
+const __b_h_planck = 6.62607015e-34*u"J*s" 
+# Planck's constant [J*s]
 const __b_h_bar_planck = __b_h_planck / 2pi
 # h_planck/twopi [eV*s]
 const __b_classical_radius_factor = __b_r_e * __b_m_electron

--- a/src/2010_constants.jl
+++ b/src/2010_constants.jl
@@ -139,8 +139,8 @@ const __b_r_p = __b_r_e * __b_m_electron / __b_m_proton
 # classical proton radius [m]
 const __b_c_light = 2.99792458e8 * u"m/s"
 # speed of light [m/s]
-const __b_h_planck = 4.135667696e-15 * u"eV*s"
-# Planck's constant [eV*s]
+const __b_h_planck = 6.62607015e-34*u"J*s" 
+# Planck's constant [J*s]
 const __b_h_bar_planck = __b_h_planck / 2pi
 # h_planck/twopi [eV*s]
 const __b_classical_radius_factor = __b_r_e * __b_m_electron

--- a/src/2014_constants.jl
+++ b/src/2014_constants.jl
@@ -146,8 +146,8 @@ const __b_r_p = __b_r_e * __b_m_electron / __b_m_proton
 # classical proton radius [m]
 const __b_c_light = 2.99792458e8 * u"m/s"
 # speed of light [m/s]
-const __b_h_planck = 4.135667696e-15 * u"eV*s"
-# Planck's constant [eV*s]
+const __b_h_planck = 6.62607015e-34*u"J*s" 
+# Planck's constant [J*s]
 const __b_h_bar_planck = __b_h_planck / 2pi
 # h_planck/twopi [eV*s]
 const __b_classical_radius_factor = __b_r_e * __b_m_electron

--- a/src/2018_constants.jl
+++ b/src/2018_constants.jl
@@ -138,8 +138,8 @@ const __b_r_p = __b_r_e * __b_m_electron / __b_m_proton
 # classical proton radius [m]
 const __b_c_light = 2.99792458e8 * u"m/s"
 # speed of light [m/s]
-const __b_h_planck = 4.135667696e-15 * u"eV*s"
-# Planck's constant [eV*s]
+const __b_h_planck = 6.62607015e-34*u"J*s" 
+# Planck's constant [J*s]
 const __b_h_bar_planck = __b_h_planck / 2pi
 # h_planck/twopi [eV*s]
 const __b_classical_radius_factor = __b_r_e * __b_m_electron

--- a/src/2022_constants.jl
+++ b/src/2022_constants.jl
@@ -142,9 +142,9 @@ const __b_r_p = __b_r_e * __b_m_electron / __b_m_proton
 # classical proton radius [m]
 const __b_c_light = 2.99792458e8 * u"m/s"
 # speed of light [m/s]
-const __b_h_planck = 4.135667696e-15 * u"eV*s"
-# Planck's constant [eV*s]
-const __b_h_bar_planck = __b_h_planck / 2pi
+const __b_h_planck = 6.62607015e-34*u"J*s" 
+# Planck's constant [J*s]
+const __b_h_bar_planck = __b_h_planck / 2 / pi
 # h_planck/twopi [eV*s]
 const __b_classical_radius_factor = __b_r_e * __b_m_electron
 # e^2 / (4 pi eps_0) = classical_radius * mass * c^2.


### PR DESCRIPTION
Switched the base constant to the exact release in J*s, so that @APCdef has:
```
APC.H_BAR_PLANCK = 1.0 h_bar
```