### PR TITLE
Export functions including constructor and spin functions with @APCdef

### DIFF
--- a/src/APCdef.jl
+++ b/src/APCdef.jl
@@ -360,6 +360,31 @@ function generate_constructor(release::AtomicAndPhysicalConstants.CODATA)
   end
 end
 
+function generate_spin_functions(release::AtomicAndPhysicalConstants.CODATA)
+  return_fxn = (release, property) -> begin
+    return quote
+      if $property == "g_spin"
+        return AtomicAndPhysicalConstants.g_spin(species, $release; signed = signed)
+      elseif $property == "gyromagnetic_anomaly"
+        return AtomicAndPhysicalConstants.gyromagnetic_anomaly(species, $release; signed = signed)
+      # elseif $property == "g_nucleon"
+      end
+    end
+  end
+
+  return quote
+    function $(esc(:g_spin))(species::AtomicAndPhysicalConstants.Species; signed::Bool = false)::Float64
+      $(return_fxn(release, "g_spin"))
+    end
+    function $(esc(:gyromagnetic_anomaly))(species::AtomicAndPhysicalConstants.Species; signed::Bool = false)::Float64
+      $(return_fxn(release, "gyromagnetic_anomaly"))
+    end
+    # function $(esc(:g_nucleon))(species::AtomicAndPhysicalConstants.Species; signed::Bool = false)::Float64
+    #   $(return_fxn(release, "g_nucleon"))
+    # end
+  end
+end
+
 
 function generate_particle_property_functions(unittype, mass_unit, charge_unit, spin_unit, energy_unit, field_unit)
   # require that the unittype is one of Float, Unitful, DynamicQuantities

--- a/src/AtomicAndPhysicalConstants.jl
+++ b/src/AtomicAndPhysicalConstants.jl
@@ -40,7 +40,7 @@ include("docstrings.jl")
 
 export @APCdef
 export ACCELERATOR, MKS, CGS
-# export Species
+export Species
 export SubatomicSpecies
 export AtomicSpecies
 # export SUBATOMIC_SPECIES

--- a/src/AtomicAndPhysicalConstants.jl
+++ b/src/AtomicAndPhysicalConstants.jl
@@ -40,11 +40,11 @@ include("docstrings.jl")
 
 export @APCdef
 export ACCELERATOR, MKS, CGS
-export Species
+# export Species
 export SubatomicSpecies
 export AtomicSpecies
 # export SUBATOMIC_SPECIES
-export ATOMIC_SPECIES
+# export ATOMIC_SPECIES
 # export useCODATAm
 export NewUnits
 export showconst

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -51,12 +51,16 @@ end
 #####################################################################
 
 
-function Species(speciesname::String)
+function Species(speciesname::String, release::AtomicAndPhysicalConstants.CODATA)
   
-  if isdefined(Main, :APCflag)
+  if !isdefined(@__MODULE__, :SUBATOMIC_SPECIES)
+    global SUBATOMIC_SPECIES = subatomic_species(release)
+  end
+
+  if 1==1
     
     # if the name is "Null", return a null Species
-    if speciesname == "Null" || speciesname == "null" || speciesname == ""
+    if speciesname == "Null" || speciesname == "null" || speciesname == "" 
       return Species()
     end
 

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -29,7 +29,7 @@ For atomic particles, will currently return 0. Will be updated in a future patch
 """
 g_spin
 
-function g_spin(species::Species; signed::Bool=false)
+function g_spin(species::Species, release::CODATA; signed::Bool=false)
 
   vtypes = [Kind.LEPTON, Kind.HADRON]
   known = ["deuteron", "electron", "helion", "muon", "neutron", "proton", "triton"]
@@ -67,7 +67,7 @@ Compute and deliver the gyromagnetic anomaly for a particle
 """
 gyromagnetic_anomaly
 
-function gyromagnetic_anomaly(species::Species; signed::Bool=false)
+function gyromagnetic_anomaly(species::Species, release::CODATA; signed::Bool=false)
 
 
   vtypes = [Kind.LEPTON, Kind.HADRON]
@@ -79,9 +79,9 @@ function gyromagnetic_anomaly(species::Species; signed::Bool=false)
     error("Only subatomic particles have computable gyromagnetic anomalies in this package.")
   else
     if signed == true
-      gs = g_spin(species)
+      gs = g_spin(species, release; signed = true)
     else
-      gs = abs(g_spin(species))
+      gs = g_spin(species, release)
     end
     return (gs - 2) / 2
   end

--- a/src/types.jl
+++ b/src/types.jl
@@ -20,9 +20,9 @@ struct Species
 end
 
 function Species() 
-  if isdefined(Main, :APCflag)
+
   return Species("Null", 0.0u"e", 0.0u"MeV/c^2", 0.0u"h_bar", 0.0u"J/T", 0, Kind.NULL)
-  end
+
 end
 
 


### PR DESCRIPTION
In an effort to avoid eval-ing from @APCdef, I now export Species(speciesname), g_spin, and gyromagnetic_anomaly from @APCdef into the scope it's called in.

SUBATOMIC_SPECIES now is defined **inside** AtomicAndPhysicalConstants the first time a user makes a call to the Species constructor - i need to change this so that it's the first time a call is made to the non-null species constructor still.

specifics on g_nucleon I'm still working on, so it isn't exported yet (though the framework to do so is there)