### PR TITLE
reverted to a single CODATA release

### DIFF
--- a/src/AtomicAndPhysicalConstants.jl
+++ b/src/AtomicAndPhysicalConstants.jl
@@ -15,7 +15,6 @@ using .NewUnits
 @reexport using Unitful
 
 include("constants_struct.jl")
-include("prerelease.jl")
 include("types.jl")
 include("2002_constants.jl")
 include("2006_constants.jl")
@@ -32,20 +31,13 @@ include("APCdef.jl")
 include("showconst.jl")
 include("docstrings.jl")
 
-# global APCflag::Bool = false
-# export APCflag;
-
-@reexport using .PreRelease
-# @reexport using .CODATA2022
-
 export @APCdef
 export ACCELERATOR, MKS, CGS
 export Species
 export SubatomicSpecies
 export AtomicSpecies
-# export SUBATOMIC_SPECIES
+export SUBATOMIC_SPECIES
 export ATOMIC_SPECIES
-# export useCODATAm
 export NewUnits
 export showconst
 export full_name, atomicnumber, g_spin, gyromagnetic_anomaly, g_nucleon, to_openPMD

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -53,146 +53,143 @@ end
 
 function Species(speciesname::String)
   
-  if isdefined(Main, :APCflag)
-    
-    # if the name is "Null", return a null Species
-    if speciesname == "Null" || speciesname == "null" || speciesname == ""
-      return Species()
-    end
-
-    name::String = speciesname
-
-    # by checking for the anti- prefix, we can determine if the particle is an anti-particle
-    # anti is true for anti-particles
-    anti::Bool = occursin(anti_regEx, name)
-    # if the particle is an anti-particle, remove the prefix for easier lookup
-    name = replace(name, anti_regEx => "")
-
-    for (k, _) in SUBATOMIC_SPECIES
-      # whether the particle is in the subatomic species dictionary
-      if occursin(k, name)
-        # whether the particle name only contains characters in the subatomic species dictionary
-        # delete all the names and spaces, there should be nothing left
-        length(k) == length(name) || "$speciesname should contain only the name of the subatomic particle"
-        if anti
-          if k == "electron"
-            return subatomic_particle("positron")
-          end
-          return subatomic_particle("anti-" * k)
-        else
-          return subatomic_particle(k)
-        end
-      end
-    end
-
-    # the atomic symbol
-    atom::String = ""
-    # the first index of the atomic symbol
-    index::Int64 = 0
-
-    function normalize_superscripts(str::String)
-      buf = IOBuffer()
-      for c in str
-        if haskey(SUPERSCRIPT_MAP, c)
-          print(buf, SUPERSCRIPT_MAP[c])  # write digit
-        elseif c == '⁺' # superscript +
-          print(buf, '+')  # write ASCII +
-        elseif c == '⁻' # superscript -
-          print(buf, '-')  # write ASCII -
-        elseif c == ' ' # remove spaces
-          continue
-        else
-          print(buf, c)  # preserve original char
-        end
-      end
-      return String(take!(buf))
-    end
-    name = normalize_superscripts(name)
-
-    # if the particle is not in the subatomic species dictionary, check the atomic species dictionary
-    for k in sorted_list_of_atomic_symbols #  sort by length to find the longest match first
-      # whether the particle is in the atomic species dictionary
-      if occursin(k, name)
-        atom = k
-        index = findfirst(k, name).start  # find the first index of the atomic symbol
-        break
-      end
-    end
-    # atom should not be empty
-    atom != "" || error("you did not specify an atomic species or subatomic species in $speciesname")
-
-
-    #check for the isotope 
-
-    #the substring before the symbol
-    left::String = name[1:index-1]
-
-    iso::Int64 = 0
-
-    #if the user choose to put isotope in the front 
-    if left != ""
-      #if the left string starts with #, delete the #
-      if left[1] == '#'
-        left = left[2:end]
-      end
-      # convert the isotope to an integer
-      for c in left
-        iso = iso * 10 + parse(Int64, c)
-      end
-      haskey(ATOMIC_SPECIES[atom].mass, iso) || error("$iso is not a valid isotope of $atom")
-    end
-
-    # if iso is not specified, use the most abundant isotope
-    if iso == 0
-      iso = -1
-    end
-
-    #now try to parse the charge
-    right::String = name[index+length(atom):end]
-    charge::Int64 = 0
-    chargenum::Int64 = 0
-    !(occursin("+", right) && occursin("-", right)) || error("You cannot have opposite charge in $speciesname")
-
-    #if the charge is positive
-    if occursin("+", right)
-      charge = count(==('+'), right)
-      #either put the charge symbol in the front or the back
-      right[1] == '+' || right[end] == '+' || error("You should only put the charge symbol in the front or the back of the atomic symbol in $speciesname")
-      # remove the charge symbol
-      right = replace(right, "+" => "")
-      for c in right
-        chargenum = chargenum * 10 + parse(Int64, c) #parse the charge number 
-      end
-      if chargenum == 0 #if the charge number is not specified
-        chargenum = 1
-      end
-      charge *= chargenum
-    elseif occursin("-", right) #if the charge is negative
-      charge = -count(==('-'), right)
-      #either put the charge symbol in the front or the back
-      right[1] == '-' || right[end] == '-' || error("You should only put the charge symbol in the front or the back of the atomic symbol in $speciesname")
-      # remove the charge symbol
-      right = replace(right, "-" => "")
-      for c in right
-        chargenum = chargenum * 10 + parse(Int64, c) #parse the charge number 
-      end
-      if chargenum == 0 #if the charge number is not specified
-        chargenum = 1
-      end
-      charge *= chargenum
-    end
-    # when the charge symbol is removed, the rest of the string should be a number
-    all(isdigit, right) || error("The charge specification should only include '+', '-' and number")
-
-    if anti
-      return create_atomic_species("anti-" * atom, charge, iso)
-    else
-      return create_atomic_species(atom, charge, iso)
-    end
-
-  else
-    error("You must make a call to @APCdef before you can define a species object.")
+  
+  # if the name is "Null", return a null Species
+  if speciesname == "Null" || speciesname == "null" || speciesname == ""
+    return Species()
   end
+
+  name::String = speciesname
+
+  # by checking for the anti- prefix, we can determine if the particle is an anti-particle
+  # anti is true for anti-particles
+  anti::Bool = occursin(anti_regEx, name)
+  # if the particle is an anti-particle, remove the prefix for easier lookup
+  name = replace(name, anti_regEx => "")
+
+  for (k, _) in SUBATOMIC_SPECIES
+    # whether the particle is in the subatomic species dictionary
+    if occursin(k, name)
+      # whether the particle name only contains characters in the subatomic species dictionary
+      # delete all the names and spaces, there should be nothing left
+      length(k) == length(name) || "$speciesname should contain only the name of the subatomic particle"
+      if anti
+        if k == "electron"
+          return subatomic_particle("positron")
+        end
+        return subatomic_particle("anti-" * k)
+      else
+        return subatomic_particle(k)
+      end
+    end
+  end
+
+  # the atomic symbol
+  atom::String = ""
+  # the first index of the atomic symbol
+  index::Int64 = 0
+
+  function normalize_superscripts(str::String)
+    buf = IOBuffer()
+    for c in str
+      if haskey(SUPERSCRIPT_MAP, c)
+        print(buf, SUPERSCRIPT_MAP[c])  # write digit
+      elseif c == '⁺' # superscript +
+        print(buf, '+')  # write ASCII +
+      elseif c == '⁻' # superscript -
+        print(buf, '-')  # write ASCII -
+      elseif c == ' ' # remove spaces
+        continue
+      else
+        print(buf, c)  # preserve original char
+      end
+    end
+    return String(take!(buf))
+  end
+  name = normalize_superscripts(name)
+
+  # if the particle is not in the subatomic species dictionary, check the atomic species dictionary
+  for k in sorted_list_of_atomic_symbols #  sort by length to find the longest match first
+    # whether the particle is in the atomic species dictionary
+    if occursin(k, name)
+      atom = k
+      index = findfirst(k, name).start  # find the first index of the atomic symbol
+      break
+    end
+  end
+  # atom should not be empty
+  atom != "" || error("you did not specify an atomic species or subatomic species in $speciesname")
+
+
+  #check for the isotope 
+
+  #the substring before the symbol
+  left::String = name[1:index-1]
+
+  iso::Int64 = 0
+
+  #if the user choose to put isotope in the front 
+  if left != ""
+    #if the left string starts with #, delete the #
+    if left[1] == '#'
+      left = left[2:end]
+    end
+    # convert the isotope to an integer
+    for c in left
+      iso = iso * 10 + parse(Int64, c)
+    end
+    haskey(ATOMIC_SPECIES[atom].mass, iso) || error("$iso is not a valid isotope of $atom")
+  end
+
+  # if iso is not specified, use the most abundant isotope
+  if iso == 0
+    iso = -1
+  end
+
+  #now try to parse the charge
+  right::String = name[index+length(atom):end]
+  charge::Int64 = 0
+  chargenum::Int64 = 0
+  !(occursin("+", right) && occursin("-", right)) || error("You cannot have opposite charge in $speciesname")
+
+  #if the charge is positive
+  if occursin("+", right)
+    charge = count(==('+'), right)
+    #either put the charge symbol in the front or the back
+    right[1] == '+' || right[end] == '+' || error("You should only put the charge symbol in the front or the back of the atomic symbol in $speciesname")
+    # remove the charge symbol
+    right = replace(right, "+" => "")
+    for c in right
+      chargenum = chargenum * 10 + parse(Int64, c) #parse the charge number 
+    end
+    if chargenum == 0 #if the charge number is not specified
+      chargenum = 1
+    end
+    charge *= chargenum
+  elseif occursin("-", right) #if the charge is negative
+    charge = -count(==('-'), right)
+    #either put the charge symbol in the front or the back
+    right[1] == '-' || right[end] == '-' || error("You should only put the charge symbol in the front or the back of the atomic symbol in $speciesname")
+    # remove the charge symbol
+    right = replace(right, "-" => "")
+    for c in right
+      chargenum = chargenum * 10 + parse(Int64, c) #parse the charge number 
+    end
+    if chargenum == 0 #if the charge number is not specified
+      chargenum = 1
+    end
+    charge *= chargenum
+  end
+  # when the charge symbol is removed, the rest of the string should be a number
+  all(isdigit, right) || error("The charge specification should only include '+', '-' and number")
+
+  if anti
+    return create_atomic_species("anti-" * atom, charge, iso)
+  else
+    return create_atomic_species(atom, charge, iso)
+  end
+
+
 end
 
 

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -30,30 +30,27 @@ For atomic particles, will currently return 0. Will be updated in a future patch
 g_spin
 
 function g_spin(species::Species; signed::Bool=false)
-  if isdefined(Main, :UNITS)
 
-    vtypes = [Kind.LEPTON, Kind.HADRON]
-    known = ["deuteron", "electron", "helion", "muon", "neutron", "proton", "triton"]
-    if getfield(species, :kind) ∉ vtypes
-      error("Only massive subatomic particles have available gyromagnetic factors in this package.")
-    end
-    if lowercase(getfield(species, :name)) ∈ known
-      valname = Symbol("__b_gspin_"*getfield(species, :name))
-      return abs(eval(valname))
-    else
-      m_s = uconvert(u"MeV/c^2", getfield(species, :mass))
-      mu_s = uconvert(u"m^2 * C / s", getfield(species, :moment))
-      spin_s = getfield(species, :spin).val # since we store spin in units [ħ], we just want the half/integer
-      if signed == true
-        charge_s = uconvert(u"C", getfield(species, :charge))
-      else
-        charge_s = abs(uconvert(u"C", getfield(species, :charge)))
-      end
-      gs = uconvert(u"h_bar", 2 * m_s * mu_s / (spin_s * charge_s)).val
-      return gs
-    end
+  vtypes = [Kind.LEPTON, Kind.HADRON]
+  known = ["deuteron", "electron", "helion", "muon", "neutron", "proton", "triton"]
+
+  if getfield(species, :kind) ∉ vtypes
+    error("Only massive subatomic particles have available gyromagnetic factors in this package.")
+  end
+  if lowercase(getfield(species, :name)) ∈ known
+    valname = Symbol("__b_gspin_"*getfield(species, :name))
+    return abs(CODATA2022.eval(valname))
   else
-    error("Please run @APCdef before you make a call to g_spin")
+    m_s = uconvert(u"MeV/c^2", getfield(species, :mass))
+    mu_s = uconvert(u"m^2 * C / s", getfield(species, :moment))
+    spin_s = getfield(species, :spin).val # since we store spin in units [ħ], we just want the half/integer
+    if signed == true
+      charge_s = uconvert(u"C", getfield(species, :charge))
+    else
+      charge_s = abs(uconvert(u"C", getfield(species, :charge)))
+    end
+    gs = uconvert(u"h_bar", 2 * m_s * mu_s / (spin_s * charge_s)).val
+    return gs
   end
 end;
 
@@ -71,41 +68,22 @@ gyromagnetic_anomaly
 
 function gyromagnetic_anomaly(species::Species; signed::Bool=false)
 
-  if isdefined(Main, :APCconsts) && isdefined(Main, :GYRO_ANOM_ELECTRON) == false
     vtypes = [Kind.LEPTON, Kind.HADRON]
     if getfield(species, :name) == "electron"
-      return getfield(Main, Symbol(Main.APCconsts)).GYRO_ANOM_ELECTRON
+      return CODATA2022.__b_gyro_anom_electron
     elseif getfield(species, :name) == "muon"
-      return getfield(Main, Symbol(Main.APCconsts)).GYRO_ANOM_MUON
+      return CODATA2022.__b_gyro_anom_muon
     elseif getfield(species, :kind) ∉ vtypes
       error("Only subatomic particles have computable gyromagnetic anomalies in this package.")
     else
       if signed == true
-        gs = g_spin(species)
+        gs = g_spin(species; signed = true)
       else
-        gs = abs(g_spin(species))
+        gs = g_spin(species)
       end
       return (gs - 2) / 2
     end
-  elseif isdefined(Main, :GYRO_ANOM_ELECTRON)
-    vtypes = [Kind.LEPTON, Kind.HADRON]
-    if getfield(species, :name) == "electron"
-      return Main.GYRO_ANOM_ELECTRON
-    elseif getfield(species, :name) == "muon"
-      return Main.GYRO_ANOM_MUON
-    elseif getfield(species, :kind) ∉ vtypes
-      error("Only subatomic particles have computable gyromagnetic anomalies in this package.")
-    else
-      if signed == true
-        gs = g_spin(species)
-      else
-        gs = abs(g_spin(species))
-      end
-      return (gs - 2) / 2
-    end
-  else
-    error("Please run @APCdef before you make a call to gyromagnetic_anomaly")
-  end
+
 end;
 
 

--- a/src/subatomic_species.jl
+++ b/src/subatomic_species.jl
@@ -57,4 +57,4 @@ function subatomic_species(CODATAYEAR::CODATA)
 end
 
 
-
+SUBATOMIC_SPECIES = subatomic_species(CODATA2022)


### PR DESCRIPTION
This branch only references CODATA2022, and so doesn't need to do any trickery with modules or evals from the @APCdef macro