### PR TITLE
Enhance species parsing logic for atomic species to enforce Bmad standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A lightweight version of AtomicAndPhysicalConstants.jl that provides atomic and 
 - **Fast compilation**: Simple static constants for optimal performance
 - **Simple API**: Easy-to-use Species struct with direct field access
 - **Comprehensive coverage**: Subatomic particles, atoms, ions, and isotopes
+- **Robust parsing**: Efficient atomic name parser with comprehensive error handling
 
 ## Comparison with AtomicAndPhysicalConstants.jl
 
@@ -64,9 +65,28 @@ e.g_factor       # g-factor (dimensionless)
 - `"photon"`
 
 ### Atomic Species
-- Supported elements: `"H"`, `"He"`, `"Li"`, `"Be"`, `"B"`, `"C"`, `"N"`, `"O"`, `"F"`, `"Ne"`, `"Na"`, `"Mg"`, `"Al"`, `"Si"`, `"P"`, `"S"`, `"Cl"`, `"Ar"`, `"K"`, `"Ca"`, `"Fe"`, `"Cu"`, `"Zn"`, `"U"`
-- Ions: `"H+"`, `"He++"`, `"C+"`, `"O-"`, etc.
-- Isotopes: `"H1"`, `"C12"`, `"U235"`, etc.
+- Supported elements from `"H"` to `"Og"`
+
+#### Mass Number Format (optional)
+- Mass number before the atomic symbol
+- Optional "#" symbol at the beginning
+- If not specified, uses the average of the mass in naturally occurring samples.
+
+```julia
+julia> Species("12C")
+julia> Species("#12C")
+```
+#### Charge Format (optional)
+- Charge number after the atomic symbol
+  - `"+"` - Single positive charge (e.g., `"C+"`)
+  - `"++"` - Double positive charge (e.g., `"C++"`)
+  - `"+n"` - n positive charges (e.g., `"C+3"`)
+  - `"n+"` - n positive charges (e.g., `"C3+"`)
+  - `"-"` - Single negative charge (e.g., `"C-"`)
+  - `"--"` - Double negative charge (e.g., `"C--"`)
+  - `"-n"` - n negative charges (e.g., `"C-2"`)
+  - `"n-"` - n negative charges (e.g., `"C2-"`)
+
 
 ## API Reference
 
@@ -151,7 +171,7 @@ println("Electron mass: ", M_ELECTRON, " eV/c²")
 electron = Species("electron")
 proton = Species("proton")
 hydrogen = Species("H")
-carbon12 = Species("C12")
+carbon12 = Species("12C")
 
 # Access properties
 println("Electron charge: ", electron.charge, " e")
@@ -189,6 +209,6 @@ APClite.ATOMIC_SPECIES["Xe"] = (
     Z=54,
     isotopes=Dict(129 => 120000.0, 132 => 122000.0, -1 => 121000.0),
 )
-xe129pp = Species("Xe129++")
+xe129pp = Species("129Xe++")
 println(xe129pp)
 ```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,7 +58,7 @@ using AtomicAndPhysicalConstants
         @test c.kind == ATOM
         
         # Carbon isotope
-        c12 = Species("C12")
+        c12 = Species("12C")
         @test nameof(c12, basename=true) == "C"
         @test nameof(c12, basename=false) == "#12C"
         @test c12.iso == 12
@@ -73,8 +73,78 @@ using AtomicAndPhysicalConstants
         @test nameof(null_species2) == "Null"
     end
     
+    @testset "Isotope Format Parsing" begin
+        # Test single digit isotopes
+        c12 = Species("12C")
+        @test c12.iso == 12
+        @test nameof(c12, basename=true) == "C"
+        @test nameof(c12, basename=false) == "#12C"
+        
+        # Test with # prefix
+        c12_hash = Species("#12C")
+        @test c12_hash.iso == 12
+        @test nameof(c12_hash, basename=false) == "#12C"
+
+        # Test no isotope number
+        c = Species("C")
+        @test c.iso == -1.0
+        @test nameof(c, basename=true) == "C"
+        @test nameof(c, basename=false) == "C"
+    end
+    
+    @testset "Charge Format Parsing" begin
+        # Test all positive charge formats
+        c_plus = Species("C+")
+        @test c_plus.charge == 1.0
+        
+        c_plus_plus = Species("C++")
+        @test c_plus_plus.charge == 2.0
+        
+        c_plus_3 = Species("C+3")
+        @test c_plus_3.charge == 3.0
+        
+        c_3_plus = Species("C3+")
+        @test c_3_plus.charge == 3.0
+        
+        # Test all negative charge formats
+        c_minus = Species("C-")
+        @test c_minus.charge == -1.0
+        
+        c_minus_minus = Species("C--")
+        @test c_minus_minus.charge == -2.0
+        
+        c_minus_2 = Species("C-2")
+        @test c_minus_2.charge == -2.0
+        
+        c_2_minus = Species("C2-")
+        @test c_2_minus.charge == -2.0
+        
+        # Test with isotopes
+        c12_plus = Species("12C+")
+        @test c12_plus.charge == 1.0
+        @test c12_plus.iso == 12
+        
+        c12_3_plus = Species("12C3+")
+        @test c12_3_plus.charge == 3.0
+        @test c12_3_plus.iso == 12
+        
+        c12_minus_2 = Species("12C-2")
+        @test c12_minus_2.charge == -2.0
+        @test c12_minus_2.iso == 12
+        
+        # Test with # prefix isotopes
+        c_hash_12_plus = Species("#12C+")
+        @test c_hash_12_plus.charge == 1.0
+        @test c_hash_12_plus.iso == 12
+    end
+    
     @testset "Error Handling" begin
         @test_throws ErrorException Species("nonexistent")
-        @test_throws ErrorException Species("H++-")  # Invalid charge format
+        @test_throws ErrorException Species("H++-")  # Invalid charge format (both + and -)
+        @test_throws ErrorException Species("C12")   # Invalid format (isotope not on left)
+        @test_throws ErrorException Species("Habc")  # Invalid characters after symbol
+        @test_throws ErrorException Species("abcC")  # Invalid characters before symbol
+        @test_throws ErrorException Species("H++")   # Unphysical charge (H can only be +1)
+        @test_throws ErrorException Species("999C")  # Invalid isotope number
     end
 end


### PR DESCRIPTION
Fixed #265. Species constructor now only accepts names following the `(iso + atom + charge)` format. Also added test cases for atom name parsing.