### PR TITLE
removed `apclite`.

### DIFF
--- a/benchmark/comparison_benchmark.jl
+++ b/benchmark/comparison_benchmark.jl
@@ -15,14 +15,14 @@ println("1. Struct Creation Comparison:")
 println("   AtomicAndPhysicalConstants Species vs Simple Struct")
 
 # AtomicAndPhysicalConstants species creation
-apclite_bench = @benchmark Species("electron")
-println("   AtomicAndPhysicalConstants Species(\"electron\"): $(round(median(apclite_bench.times) / 1000, digits=3)) μs")
+apc_bench = @benchmark Species("electron")
+println("   AtomicAndPhysicalConstants Species(\"electron\"): $(round(median(apc_bench.times) / 1000, digits=3)) μs")
 
 # Simple struct creation
 simple_bench = @benchmark SimpleParticle("electron", 0.511, -1.0)
 println("   SimpleParticle(\"electron\", 0.511, -1.0): $(round(median(simple_bench.times) / 1000, digits=3)) μs")
 
-overhead = median(apclite_bench.times) / median(simple_bench.times)
+overhead = median(apc_bench.times) / median(simple_bench.times)
 println("   AtomicAndPhysicalConstants overhead: $(round(overhead, digits=2))x")
 println()
 
@@ -31,12 +31,12 @@ println("2. Constant Access Comparison:")
 println("   AtomicAndPhysicalConstants constants vs hardcoded values")
 
 # AtomicAndPhysicalConstants constants
-apclite_const = @benchmark begin
+apc_const = @benchmark begin
     c = C_LIGHT
     h = H_PLANCK
     e = E_CHARGE
 end
-println("   AtomicAndPhysicalConstants constants: $(round(median(apclite_const.times) / 1000, digits=4)) μs")
+println("   AtomicAndPhysicalConstants constants: $(round(median(apc_const.times) / 1000, digits=4)) μs")
 
 # Hardcoded values
 hardcoded_bench = @benchmark begin
@@ -46,7 +46,7 @@ hardcoded_bench = @benchmark begin
 end
 println("   Hardcoded values: $(round(median(hardcoded_bench.times) / 1000, digits=4)) μs")
 
-const_overhead = median(apclite_const.times) / median(hardcoded_bench.times)
+const_overhead = median(apc_const.times) / median(hardcoded_bench.times)
 println("   AtomicAndPhysicalConstants overhead: $(round(const_overhead, digits=2))x")
 println()
 
@@ -62,14 +62,14 @@ particle_dict = Dict(
 )
 
 # AtomicAndPhysicalConstants species creation
-apclite_species = @benchmark Species("electron")
-println("   AtomicAndPhysicalConstants Species(\"electron\"): $(round(median(apclite_species.times) / 1000, digits=3)) μs")
+apc_species = @benchmark Species("electron")
+println("   AtomicAndPhysicalConstants Species(\"electron\"): $(round(median(apc_species.times) / 1000, digits=3)) μs")
 
 # Dictionary lookup
 dict_bench = @benchmark particle_dict["electron"]
 println("   Dictionary lookup: $(round(median(dict_bench.times) / 1000, digits=3)) μs")
 
-lookup_overhead = median(apclite_species.times) / median(dict_bench.times)
+lookup_overhead = median(apc_species.times) / median(dict_bench.times)
 println("   AtomicAndPhysicalConstants overhead: $(round(lookup_overhead, digits=2))x")
 println()
 
@@ -78,13 +78,13 @@ println("4. Memory Usage Comparison:")
 println("   AtomicAndPhysicalConstants Species vs Simple Struct")
 
 # AtomicAndPhysicalConstants memory
-apclite_memory = @benchmark Species("electron")
-println("   AtomicAndPhysicalConstants Species: $(round(median(apclite_memory.memory), digits=0)) bytes")
+apc_memory = @benchmark Species("electron")
+println("   AtomicAndPhysicalConstants Species: $(round(median(apc_memory.memory), digits=0)) bytes")
 
 # Simple struct memory
 simple_memory = @benchmark SimpleParticle("electron", 0.511, -1.0)
 println("   SimpleParticle: $(round(median(simple_memory.memory), digits=0)) bytes")
 
-memory_overhead = median(apclite_memory.memory) / median(simple_memory.memory)
+memory_overhead = median(apc_memory.memory) / median(simple_memory.memory)
 println("   AtomicAndPhysicalConstants memory overhead: $(round(memory_overhead, digits=2))x")
 println()

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,6 +1,6 @@
 # AtomicAndPhysicalConstants/src/types.jl
 
-# This module defines the core data structures used in APClite.
+# This module defines the core data structures used in APC.
 """
     Species(speciesname::String)
     Species()


### PR DESCRIPTION
Renamed `apclite` to `apc` since lite version no longer exists.