### PR TITLE
Express EPS_0 in 1/(eV*m) and MU_0 in eV*s^2/m

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AtomicAndPhysicalConstants"
 uuid = "5c0d271c-5419-4163-b387-496237733d8b"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["David Sagan <david.sagan@cornell.edu>, Alex Coxe <rot4te@gmail.com>, and contributors"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -213,8 +213,8 @@ Both Pion masses are obtained from PDG, rather than CODATA.
 - `H_PLANCK`: Planck's constant in [eV⋅s]
 - `H_BAR`: Planck's reduced constant in [eV⋅s]
 - `CLASSICAL_RADIUS_FACTOR` 
-- `EPS_0`: Permittivity of free space in [F/m]
-- `MU_0`: Vacuum Permeability in [N/A^2]
+- `EPS_0`: Permittivity of free space in [1/(eV⋅m)]
+- `MU_0`: Vacuum Permeability in [eV⋅s²/m]
 
 
 ### Conversion Constants

--- a/docs/src/man/constants.md
+++ b/docs/src/man/constants.md
@@ -88,8 +88,8 @@ The gyromagnetic anomaly is defined as ``a = (g - 2)/2``.
 | `R_PROTON` | classical proton radius | m |
 | `CLASSICAL_RADIUS_FACTOR` | ``e^2 / (4\pi\varepsilon_0) = r_e m_e c^2`` | eV·m |
 | `K_BOLTZMANN` | Bolzmann's constant k<sub>B<sub> | eV/K |
-| `EPS_0` | permittivity of free space | F/m |
-| `MU_0` | vacuum permeability | N/A² |
+| `EPS_0` | permittivity of free space | 1/(eV·m) |
+| `MU_0` | vacuum permeability | eV·s²/m |
 | `AVOGADRO` | Avogadro's constant | mol⁻¹ |
 | `FINE_STRUCTURE` | fine-structure constant | dimensionless |
 | `RELEASE_YEAR` | active CODATA release year | — |

--- a/src/CODATA2002.jl
+++ b/src/CODATA2002.jl
@@ -114,10 +114,10 @@ CLASSICAL_RADIUS_FACTOR = 2.8179403205e-15 * 0.51099895069, # R_ELECTRON* m_elec
 K_BOLTZMANN = 8.61734315e-5,
 #k_B in eV/K
 
-EPS_0= 8.8541878188e-12,
-# Permittivity of free space in [F/m]
-MU_0 = 1.25663706127e-6,
-# Vacuum permeability in [N/A^2] (newtons per ampere squared)
+EPS_0= 5.5263493618e7,
+# Permittivity of free space in [1/(eV*m)]
+MU_0 = 2.0133545370e-25,
+# Vacuum permeability in [eV*s^2/m]
 
 
 

--- a/src/CODATA2006.jl
+++ b/src/CODATA2006.jl
@@ -116,10 +116,10 @@ CLASSICAL_RADIUS_FACTOR = 2.8179403205e-15 * 0.51099895069, # R_ELECTRON* m_elec
 K_BOLTZMANN=8.61734315e-5,
 #k_B in eV/K
 
-EPS_0 = 8.8541878188e-12,
-# Permittivity of free space in [F/m]
-MU_0 = 1.25663706127e-6,
-# Vacuum permeability in [N/A^2] (newtons per ampere squared)
+EPS_0 = 5.5263493618e7,
+# Permittivity of free space in [1/(eV*m)]
+MU_0 = 2.0133545370e-25,
+# Vacuum permeability in [eV*s^2/m]
 
 
 G_PER_AMU=1.66053906892e-24,

--- a/src/CODATA2010.jl
+++ b/src/CODATA2010.jl
@@ -119,10 +119,10 @@ CLASSICAL_RADIUS_FACTOR = 2.8179403205e-15 * 0.51099895069, # R_ELECTRON * m_ele
 K_BOLTZMANN=8.61733324e-5,
 #k_B in eV/K
 
-EPS_0 = 8.8541878188e-12,
-# Permittivity of free space in [F/m]
-MU_0 = 1.25663706127e-6,
-# Vacuum permeability in [N/A^2] (newtons per ampere squared)
+EPS_0 = 5.5263493618e7,
+# Permittivity of free space in [1/(eV*m)]
+MU_0 = 2.0133545370e-25,
+# Vacuum permeability in [eV*s^2/m]
 
 
 G_PER_AMU=1.66053906892e-24,

--- a/src/CODATA2014.jl
+++ b/src/CODATA2014.jl
@@ -118,10 +118,10 @@ CLASSICAL_RADIUS_FACTOR = 2.8179403205e-15 * 0.51099895069, # R_ELECTRON * m_ele
 K_BOLTZMANN = 8.6173303e-5,
 #k_B in eV/K
 
-EPS_0 = 8.8541878188e-12,
-# Permittivity of free space in [F/m]
-MU_0 = 1.25663706127e-6,
-# Vacuum permeability in [N/A^2] (newtons per ampere squared)
+EPS_0 = 5.5263493618e7,
+# Permittivity of free space in [1/(eV*m)]
+MU_0 = 2.0133545370e-25,
+# Vacuum permeability in [eV*s^2/m]
 
 
 G_PER_AMU=1.66053906892e-23,

--- a/src/CODATA2018.jl
+++ b/src/CODATA2018.jl
@@ -118,10 +118,10 @@ CLASSICAL_RADIUS_FACTOR = 2.8179403205e-15 * 0.51099895069, # R_ELECTRON * m_ele
 K_BOLTZMANN = 8.617333262e-5,
 #k_B in eV/K
 
-EPS_0 = 8.8541878188e-12,
-# Permittivity of free space in [F/m]
-MU_0 = 1.25663706127e-6,
-# Vacuum permeability in [N/A^2] (newtons per ampere squared)
+EPS_0 = 5.5263493618e7,
+# Permittivity of free space in [1/(eV*m)]
+MU_0 = 2.0133545370e-25,
+# Vacuum permeability in [eV*s^2/m]
 
 
 G_PER_AMU=1.66053906892e-24,

--- a/src/CODATA2022.jl
+++ b/src/CODATA2022.jl
@@ -133,10 +133,10 @@ CLASSICAL_RADIUS_FACTOR = 2.8179403205e-15 * 0.51099895069, # R_ELECTRON * m_ele
 K_BOLTZMANN = 8.617333262e-5,
 #k_B in eV/K
 
-EPS_0 = 8.8541878188e-12,
-# Permittivity of free space in [F/m]
-MU_0 = 1.25663706127e-6,
-# Vacuum permeability in [N/A^2] (newtons per ampere squared)
+EPS_0 = 5.5263493618e7,
+# Permittivity of free space in [1/(eV*m)]
+MU_0 = 2.0133545370e-25,
+# Vacuum permeability in [eV*s^2/m]
 
 
 

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -214,15 +214,15 @@ K_BOLTZMANN::Float64 - Boltzmann constant k_B in eV/K per the selected CODATA re
 """
 const K_BOLTZMANN::Float64 = _ACTIVE.K_BOLTZMANN
 """
-EPS_0::Float64 - Permittivity of free space in F/m per the selected CODATA release.
+EPS_0::Float64 - Permittivity of free space in 1/(eV*m) per the selected CODATA release.
 """
 const EPS_0::Float64 = _ACTIVE.EPS_0
-# Permittivity of free space in [F/m]
+# Permittivity of free space in [1/(eV*m)]
 """
-MU_0::Float64 - Vacuum permeability in N/A^2 per the selected CODATA release.
+MU_0::Float64 - Vacuum permeability in eV*s^2/m per the selected CODATA release.
 """
 const MU_0::Float64 = _ACTIVE.MU_0
-# Vacuum permeability in [N/A^2] (newtons per ampere squared)
+# Vacuum permeability in [eV*s^2/m]
 
 """
 KG_PER_AMU::Float64 - Kilograms per Dalton conversion in the selected CODATA release.

--- a/src/types.jl
+++ b/src/types.jl
@@ -263,9 +263,9 @@ CODATA2014.C_LIGHT      # speed of light from the 2014 release
   # Boltzmann factor k_B in eV/K
 
   EPS_0::Float64
-  # Permittivity of free space in [F/m]
+  # Permittivity of free space in [1/(eV*m)]
   MU_0::Float64
-  # Vacuum permeability in [N/A^2] (newtons per ampere squared)
+  # Vacuum permeability in [eV*s^2/m]
 
 
   #######################################

--- a/test/values_test.jl
+++ b/test/values_test.jl
@@ -45,8 +45,8 @@
   @test R_ELECTRON ≈ 2.8179403205e-15  # classical electron radius in m
   @test R_PROTON ≈ 1.5346982640795807e-18
   @test CLASSICAL_RADIUS_FACTOR ≈ 1.4399645468825422e-15
-  @test EPS_0 ≈ 8.8541878188e-12  # permittivity of free space in F/m
-  @test MU_0 ≈ 1.25663706127e-6  # vacuum permeability in N/A^2
+  @test EPS_0 ≈ 5.5263493618e7  # permittivity of free space in 1/(eV*m)
+  @test MU_0 ≈ 2.0133545370e-25  # vacuum permeability in eV*s^2/m
   @test isapprox(K_BOLTZMANN, 8.61733e-5, atol=2e-10)
   @test RELEASE_YEAR == 2022
 


### PR DESCRIPTION
## Summary
Converts the vacuum permittivity (`EPS_0`) and permeability (`MU_0`) constants to the package's eV-based unit system, consistent with the ongoing J→eV work.

Working in units of eV (energy), elementary charge (charge), and m (length):

| Constant | Old (SI) | New (eV units) |
|----------|----------|----------------|
| `EPS_0` | `8.8541878188e-12` F/m | `5.5263493618e7` 1/(eV·m) |
| `MU_0` | `1.25663706127e-6` N/A² | `2.0133545370e-25` eV·s²/m |

## Verification
- `1/(EPS_0*MU_0) = 8.9876e16 = C_LIGHT²` ✓
- The relation `e²/(4πε₀) = r_e·m_e·c²` holds dimensionally with charge counted in units of `e`.
- Full test suite passes (`values_test.jl` updated).

## Changes
- All six `CODATA*.jl` releases: numeric values + unit comments.
- `src/constants.jl`, `src/types.jl`: docstrings / field comments.
- `docs/src/man/constants.md`, `README.md`: units table entries.
- `test/values_test.jl`: expected values.

`update/update_constants.jl` is left unchanged — it fetches raw NIST values that genuinely are in SI, so its `u"F/m"` / `u"N/A^2"` annotations correctly describe the raw data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
