### PR TITLE
Now hash symbol is mandated when specifying atomic number.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AtomicAndPhysicalConstants"
 uuid = "5c0d271c-5419-4163-b387-496237733d8b"
-version = "0.10.0"
+version = "0.12.0"
 authors = ["David Sagan <david.sagan@cornell.edu>, Alex Coxe <rot4te@gmail.com>, and contributors"]
 
 [deps]

--- a/docs/src/man/species.md
+++ b/docs/src/man/species.md
@@ -54,13 +54,13 @@ The full format for an atomic species string is:
 
 where both `mass_number` and `charge` are optional.
 
-**Mass number** — may be written as ordinary ASCII digits, ASCII digits preceded
-by `#`, or Unicode superscript digits:
+**Mass number** — when given as ASCII digits it must be preceded by `#`; it may
+also be written with Unicode superscript digits (no `#` needed). A bare ASCII
+mass number such as `"4He"` is **not** accepted:
 
 ```julia
 Species("He")    # helium, abundance-averaged mass
-Species("4He")   # helium-4
-Species("#4He")  # helium-4  (# prefix is accepted)
+Species("#4He")  # helium-4  (# prefix is required for ASCII digits)
 Species("⁴He")   # helium-4  (Unicode superscript)
 ```
 

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -148,11 +148,18 @@ function Species(speciesname::String)
   anti = occursin(anti_regEx, speciesname)
   # # if the particle is an anti-particle, remove the prefix for easier lookup
   !anti ? (name = speciesname) : (name = replace(speciesname, anti_regEx => ""))
-  
+
+  # A leading run of Unicode superscript digits denotes the mass number (e.g. "⁴He").
+  # Rewrite it to the canonical `#`-prefixed form so that a mass number given as
+  # plain ASCII digits always requires an explicit `#` (e.g. "#4He", not "4He").
+  if !isempty(name) && haskey(SUPERSCRIPT_MAP, first(name))
+    name = "#" * name
+  end
+
   name = normalize_superscripts(name)
 
-
-  m = match(r"^#?(\d+)?([A-Z][a-z]?)([+-].*)?$", name)   # This captures iso, species, charge as m.captures[1,2,3]
+  # The `#` is mandatory whenever an (ASCII) mass number is given.
+  m = match(r"^(?:#(\d+))?([A-Z][a-z]?)([+-].*)?$", name)   # This captures iso, species, charge as m.captures[1,2,3]
 
   # Parse species
   (m !== nothing && haskey(ATOMIC_SPECIES, m.captures[2])) ||

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -19,8 +19,9 @@ convention:
 ```julia
 nameof(Species("electron"))   # "electron"
 nameof(Species("Fe"))         # "Fe"
-nameof(Species("4He+2"))      # "#4He+2"
+nameof(Species("#4He+2"))     # "#4He+2"
 nameof(Species("Li+"))        # "Li+1"
+nameof(Species("anti-#4He"))  # "anti-#4He"
 ```
 """
 function Base.nameof(species::Species)
@@ -38,12 +39,20 @@ function Base.nameof(species::Species)
   else
     iso = getfield(species, :iso)
     charge = Int(getfield(species, :charge))
-    if charge > 0
-      return "#$iso" * getfield(species, :name) * "+$charge"
-    elseif charge < 0
-      return "#$iso" * getfield(species, :name) * "$charge"
+    name = getfield(species, :name)
+    # For anti-atoms the stored name is "anti-<symbol>"; the mass-number prefix
+    # belongs on the symbol, giving "anti-#<iso><symbol>" (not "#<iso>anti-...").
+    if startswith(name, "anti-")
+      base = "anti-#$iso" * chopprefix(name, "anti-")
     else
-      return "#$iso" * getfield(species, :name)
+      base = "#$iso" * name
+    end
+    if charge > 0
+      return base * "+$charge"
+    elseif charge < 0
+      return base * "$charge"
+    else
+      return base
     end
   end
 end

--- a/test/function_test.jl
+++ b/test/function_test.jl
@@ -4,7 +4,7 @@
 @testset "getfield tests" begin
   # Create test species
   e = Species("electron")
-  C = Species("12C")
+  C = Species("#12C")
   nas = Species()
 
   # Test nameof function
@@ -81,15 +81,18 @@ end
 @testset "nameof" begin
   @test nameof(Species("electron")) == "electron"
   @test nameof(Species("Fe")) == "Fe"
-  @test nameof(Species("4He+2")) == "#4He+2"
+  @test nameof(Species("#4He+2")) == "#4He+2"
+  @test nameof(Species("anti-#4He")) == "anti-#4He"  # mass number sits after "anti-"
+  @test nameof(Species("anti-#4He-2")) == "anti-#4He-2"
   @test nameof(Species("Li+")) == "Li+1"
   @test nameof(Species("K-2")) == "K-2"
   @test nameof(Species("H")) == "H"
 
   # round-trips through the string constructor for charged/isotope/anti species
-  for spec in ("H", "4He", "Li+3", "K-2", "Fe+10", "anti-H", "anti-4He")
+  for spec in ("H", "#4He", "Li+3", "K-2", "Fe+10", "anti-H", "anti-#4He")
     s = Species(spec)
     n = nameof(s)
+    @test n == spec  # these inputs are already in canonical form
     s2 = Species(n)
     @test nameof(s2) == n
     @test chargeof(s2) == chargeof(s)
@@ -134,6 +137,6 @@ end
   @test occursin("Charge: 3 e", out)  # displayed as an integer, not 3.0
   @test occursin("Kind: ATOM", out)
 
-  out_iso = sprint(show, MIME("text/plain"), Species("anti-4He"))
+  out_iso = sprint(show, MIME("text/plain"), Species("anti-#4He"))
   @test occursin("Atomic Number: -2", out_iso)  # does not crash for anti-atoms
 end

--- a/test/species_test.jl
+++ b/test/species_test.jl
@@ -42,11 +42,12 @@ end
   @test massof(H, AMU=true) ≈ 1.0079407540557772
 
   # mass-number prefix notations are equivalent
-  he4_ascii = Species("4He")
   he4_hash = Species("#4He")
   he4_super = Species("⁴He")
-  @test massof(he4_ascii) == massof(he4_hash) == massof(he4_super)
-  @test iso_of(he4_ascii) == iso_of(he4_hash) == iso_of(he4_super) == 4
+  @test massof(he4_hash) == massof(he4_super)
+  @test iso_of(he4_hash) == iso_of(he4_super) == 4
+  # a bare ASCII mass number requires the `#` prefix
+  @test_throws ErrorException Species("4He")
 
   # multi-letter symbols and high-Z elements
   Fe = Species("Fe")
@@ -55,7 +56,7 @@ end
   @test atomicnumberof(Og) == 118
 
   # isotope mass is exact (12C defines the amu scale)
-  C12 = Species("12C")
+  C12 = Species("#12C")
   @test massof(C12, AMU=true) ≈ 12.0
   @test spinof(C12) == 6.0  # 0.5 * iso
 
@@ -75,7 +76,7 @@ end
   @test kindof(antiH) == Kind.ATOM
   @test nameof(antiH) == "anti-H"
   @test atomicnumberof(antiH) == -1  # negative Z distinguishes anti-atoms
-  @test atomicnumberof(Species("anti-4He")) == -2
+  @test atomicnumberof(Species("anti-#4He")) == -2
 end
 
 
@@ -96,7 +97,8 @@ end
 
 @testset "Species construction: errors" begin
   @test_throws ErrorException Species("Xx")              # not a known species
-  @test_throws ErrorException Species("999H")             # invalid isotope
+  @test_throws ErrorException Species("#999H")            # invalid isotope
+  @test_throws ErrorException Species("3He")              # ASCII mass number requires '#'
   @test_throws ErrorException Species("Li+-")              # ambiguous charge
   @test_throws ErrorException Species("H+2")               # charge exceeds Z
   @test_throws ErrorException Species("Li1")               # missing +/- specifier

--- a/test/type_stable_test.jl
+++ b/test/type_stable_test.jl
@@ -20,6 +20,6 @@
   @test (@inferred isnullspecies(e)) isa Bool
   @test (@inferred nameof(e)) isa String
   @test (@inferred Species("electron")) isa Species
-  @test (@inferred Species("4He")) isa Species
+  @test (@inferred Species("#4He")) isa Species
 end
 


### PR DESCRIPTION
Follows OpenPMD See #290 