### PR TITLE
corrected CLASSICAL_RADIUS_FACTOR

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AtomicAndPhysicalConstants"
 uuid = "5c0d271c-5419-4163-b387-496237733d8b"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["David Sagan <david.sagan@cornell.edu>, Alex Coxe <rot4te@gmail.com>, and contributors"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Both Pion masses are obtained from PDG, rather than CODATA.
 - `C_LIGHT`: speed of light in [m/s]
 - `H_PLANCK`: Planck's constant in [eV⋅s]
 - `H_BAR`: Planck's reduced constant in [eV⋅s]
-- `CLASSICAL_RADIUS_FACTOR` 
+- `CLASSICAL_RADIUS_FACTOR`: classical radius factor e²/(4πε₀) = rₑmₑc² in [eV⋅m], derived as `R_ELECTRON * M_ELECTRON`
 - `EPS_0`: Permittivity of free space in [1/(eV⋅m)]
 - `MU_0`: Vacuum Permeability in [eV⋅s²/m]
 

--- a/docs/src/man/codata.md
+++ b/docs/src/man/codata.md
@@ -71,6 +71,11 @@ The pion masses (`M_PION_0`, `M_PION_CHARGED`) are not published in any CODATA
 release.  They are taken from Particle Data Group (PDG) tables and remain
 constant regardless of the selected release year.
 
+`CLASSICAL_RADIUS_FACTOR` is derived rather than tabulated: it is computed as
+`R_ELECTRON * M_ELECTRON` from the active release.  It is therefore not a field
+of the `CODATA_release` structs — `CODATA2018.CLASSICAL_RADIUS_FACTOR` does not
+exist, only the exported top-level constant.
+
 The gyromagnetic anomalies (`ANOMALY_ELECTRON`, `ANOMALY_MUON`) and the helion
 g-factor (`G_HELION`) were not individually tabulated by CODATA until the 2010
 release.  Using a pre-2010 release will still define these symbols; worth

--- a/docs/src/man/constants.md
+++ b/docs/src/man/constants.md
@@ -90,13 +90,18 @@ The gyromagnetic anomaly is defined as ``a = (g - 2)/2``.
 | `H_BAR` | reduced Planck constant *ħ* | eV·s |
 | `R_ELECTRON` | classical electron radius | m |
 | `R_PROTON` | classical proton radius | m |
-| `CLASSICAL_RADIUS_FACTOR` | ``e^2 / (4\pi\varepsilon_0) = r_e m_e c^2`` | eV·m |
+| `CLASSICAL_RADIUS_FACTOR` | ``e^2 / (4\pi\varepsilon_0) = r_e m_e c^2`` † | eV·m |
 | `K_BOLTZMANN` | Bolzmann's constant k<sub>B<sub> | eV/K |
 | `EPS_0` | permittivity of free space | 1/(eV·m) |
 | `MU_0` | vacuum permeability | eV·s²/m |
 | `AVOGADRO` | Avogadro's constant | mol⁻¹ |
 | `FINE_STRUCTURE` | fine-structure constant | dimensionless |
 | `RELEASE_YEAR` | active CODATA release year | — |
+
+† `CLASSICAL_RADIUS_FACTOR` is not a tabulated CODATA value; it is computed as
+`R_ELECTRON * M_ELECTRON` from the active release.  It is the same for all
+particles of charge ±1.  Because it is derived, it is not a field of the
+`CODATA_release` structs (e.g. there is no `CODATA2022.CLASSICAL_RADIUS_FACTOR`).
 
 
 ---

--- a/src/CODATA2002.jl
+++ b/src/CODATA2002.jl
@@ -109,7 +109,7 @@ H_PLANCK = 4.13566743e-15,
 # Planck's constant [J*s]
 H_BAR = 6.58211915e-16,
 # h_planck/twopi [eV*s]
-CLASSICAL_RADIUS_FACTOR = 2.8179403205e-15 * 0.51099895069, # R_ELECTRON* m_electron,
+# CLASSICAL_RADIUS_FACTOR = 2.8179403205e-15 * 0.51099895069, # R_ELECTRON* m_electron,
 # e^2 / (4 pi eps_0)::typeof() = classical_radius * mass * c^2.
 # Is same for all particles of charge +/- 1.
 

--- a/src/CODATA2006.jl
+++ b/src/CODATA2006.jl
@@ -111,7 +111,7 @@ H_PLANCK = 4.13566733e-15,
 # Planck's constant [eV*s]
 H_BAR = 6.58211899e-16,
 # h_planck/twopi [eV*s]
-CLASSICAL_RADIUS_FACTOR = 2.8179403205e-15 * 0.51099895069, # R_ELECTRON* m_electron,
+# CLASSICAL_RADIUS_FACTOR = 2.8179403205e-15 * 0.51099895069, # R_ELECTRON* m_electron,
 # e^2 / (4 pi eps_0)::typeof() = classical_radius * mass * c^2.
 # Is same for all particles of charge +/- 1.
 

--- a/src/CODATA2010.jl
+++ b/src/CODATA2010.jl
@@ -114,7 +114,7 @@ H_PLANCK = 4.135667516e-15,
 # Planck's constant [eV*s]
 H_BAR = 6.58211928e-16,
 # h_planck/twopi [eV*s]
-CLASSICAL_RADIUS_FACTOR = 2.8179403205e-15 * 0.51099895069, # R_ELECTRON * m_electron,
+# CLASSICAL_RADIUS_FACTOR = 2.8179403205e-15 * 0.51099895069, # R_ELECTRON * m_electron,
 # e^2 / (4 pi eps_0)::typeof() = classical_radius * mass * c^2.
 # Is same for all particles of charge +/- 1.
 

--- a/src/CODATA2014.jl
+++ b/src/CODATA2014.jl
@@ -113,7 +113,7 @@ H_PLANCK = 4.135667662e-15,
 # Planck's constant [eV*s]
 H_BAR = 6.582119514e-16,
 # h_planck/twopi [eV*s]
-CLASSICAL_RADIUS_FACTOR = 2.8179403205e-15 * 0.51099895069, # R_ELECTRON * m_electron,
+# CLASSICAL_RADIUS_FACTOR = 2.8179403205e-15 * 0.51099895069, # R_ELECTRON * m_electron,
 # e^2 / (4 pi eps_0) = classical_radius * mass * c^2.
   # Is same for all particles of charge +/- 1.
 

--- a/src/CODATA2018.jl
+++ b/src/CODATA2018.jl
@@ -113,7 +113,7 @@ H_PLANCK = 4.135667696e-15,
 # Planck's constant [eV*s]
 H_BAR = 6.582119569e-16,
 # h_planck/twopi [eV*s]
-CLASSICAL_RADIUS_FACTOR = 2.8179403205e-15 * 0.51099895069, # R_ELECTRON * m_electron,
+# CLASSICAL_RADIUS_FACTOR = 2.8179403205e-15 * 0.51099895069, # R_ELECTRON * m_electron,
 # e^2 / (4 pi eps_0)::typeof() = classical_radius * mass * c^2.
   # Is same for all particles of charge +/- 1.
 

--- a/src/CODATA2022.jl
+++ b/src/CODATA2022.jl
@@ -130,7 +130,7 @@ H_PLANCK = 4.135667696e-15,
 # Planck's constant [eV*s]
 H_BAR = 6.582119569e-16,
 # h_planck/twopi [eV*s]
-CLASSICAL_RADIUS_FACTOR = 2.8179403205e-15 * 0.51099895069, # R_ELECTRON * m_electron,
+# CLASSICAL_RADIUS_FACTOR = 2.8179403205e-15 * 0.51099895069, # R_ELECTRON * m_electron,
 # e^2 / (4 pi eps_0) = classical_radius * mass * c^2.
 # Is same for all particles of charge +/- 1.
 

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -208,9 +208,9 @@ H_BAR::Float64 - Planck's reduced constant (ħ) in eV*s per the selected CODATA 
 const H_BAR::Float64 = _ACTIVE.H_BAR
 # h_planck/twopi [eV*s]
 """
-CLASSICAL_RADIUS_FACTOR::Float64 - Classical radius factor per the selected CODATA release.
+CLASSICAL_RADIUS_FACTOR::Float64 - Classical radius factor derived from the selected CODATA release.
 """
-const CLASSICAL_RADIUS_FACTOR::Float64 = _ACTIVE.CLASSICAL_RADIUS_FACTOR # R_ELECTRON * m_electron,
+const CLASSICAL_RADIUS_FACTOR::Float64 = _ACTIVE.R_ELECTRON * _ACTIVE.M_ELECTRON # R_ELECTRON * M_ELECTRON,
 # e^2 / (4 pi eps_0)::Float64 = classical_radius * mass * c^2.
 # Is same for all particles of charge +/- 1.
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -257,7 +257,7 @@ CODATA2014.C_LIGHT      # speed of light from the 2014 release
   # Planck's constant [J*s]
   H_BAR::Float64
   # h_planck/twopi [J*s]
-  CLASSICAL_RADIUS_FACTOR::Float64
+  # CLASSICAL_RADIUS_FACTOR::Float64
   # e^2 / (4 pi eps_0) = classical_radius*mass*c^2.
   # Is same for all particles of charge +/- 1.
 

--- a/test/values_test.jl
+++ b/test/values_test.jl
@@ -44,7 +44,7 @@
   @test H_BAR ≈ 6.582119569e-16  # reduced Planck constant
   @test R_ELECTRON ≈ 2.8179403205e-15  # classical electron radius in m
   @test R_PROTON ≈ 1.5346982640795807e-18
-  @test CLASSICAL_RADIUS_FACTOR ≈ 1.4399645468825422e-15
+  @test CLASSICAL_RADIUS_FACTOR ≈ 1.4399645468825422e-9
   @test EPS_0 ≈ 5.5263493618e7  # permittivity of free space in 1/(eV*m)
   @test MU_0 ≈ 2.0133545370e-25  # vacuum permeability in eV*s^2/m
   @test isapprox(K_BOLTZMANN, 8.61733e-5, atol=2e-10)


### PR DESCRIPTION
CLASSICAL_RADIUS_FACTOR now defined in constants.jl as:
`_ACTIVE.R_ELECTRON * _ACTIVE.M_ELECTRON`
it was previously taking the wrong value because the electron mass was hard coded in MeV/c^2.