### PR TITLE
Correct isotope naming docs (`#` prefix required for ASCII mass number)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AtomicAndPhysicalConstants"
 uuid = "5c0d271c-5419-4163-b387-496237733d8b"
-version = "0.11.2"
+version = "0.11.3"
 authors = ["David Sagan <david.sagan@cornell.edu>, Alex Coxe <rot4te@gmail.com>, and contributors"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ julia> p = Species("proton"); # suppress the output for the rest of the definiti
 
 julia> h = Species("H"); # a neutral hydrogen atom
 
-julia> he = Species("3He"); # a neutral helium atom with mass number 3
+julia> he = Species("#3He"); # a neutral helium atom with mass number 3
 
 julia> h_ion = Species("H+"); # a hydrogen atom with one less electron than usual
 
@@ -107,10 +107,10 @@ Atomic numbers from 1 (`"H"`) to 118 (`"Og"`) are available with the `Species()`
 
 #### Mass Number Formatting
 
-To access different isotopes of a particular atomic element, two different syntax option are available:
+To access different isotopes of a particular atomic element, two different syntax options are available: a `#`-prefixed ASCII mass number, or a Unicode superscript mass number. A bare ASCII mass number (e.g. `"5He"`) is **not** accepted.
 
 ```julia-repl
-julia> he = Species("#5He"); he5 = Species("5He");
+julia> he = Species("#5He"); he5 = Species("⁵He");
 
 julia>  massof(he5, AMU=true)
 5.012057

--- a/benchmark/BENCHMARK_RESULTS.md
+++ b/benchmark/BENCHMARK_RESULTS.md
@@ -75,11 +75,11 @@ Species("H+"): 0.540 μs
 Species("He++"): 0.571 μs
 Species("C+"): 0.537 μs
 Species("O-"): 0.585 μs
-Species("1H"): 0.492 μs
-Species("12C"): 0.501 μs
-Species("13C"): 0.500 μs
-Species("235U"): 0.519 μs
-Species("238U"): 0.515 μs
+Species("#1H"): 0.492 μs
+Species("#12C"): 0.501 μs
+Species("#13C"): 0.500 μs
+Species("#235U"): 0.519 μs
+Species("#238U"): 0.515 μs
 ```
 
 Atomic and ionic species generally take longer to construct than subatomic particles since parsing involves element symbol/mass-number/charge-state lookups; subatomic particles are simple dictionary lookups in `SUBATOMIC_SPECIES`. Species construction across the board is substantially faster than in the previous benchmark run, consistent with the constructor efficiency work in `constructors.jl`.

--- a/benchmark/apc_performance_test.jl
+++ b/benchmark/apc_performance_test.jl
@@ -69,11 +69,11 @@ ion_benchmark = @benchmark begin
     he_plus_plus = Species("He++")
     c_plus = Species("C+")
     o_minus = Species("O-")
-    h1 = Species("1H")
-    c12 = Species("12C")
-    c13 = Species("13C")
-    u235 = Species("235U")
-    u238 = Species("238U")
+    h1 = Species("#1H")
+    c12 = Species("#12C")
+    c13 = Species("#13C")
+    u235 = Species("#235U")
+    u238 = Species("#238U")
 end
 
 println("   Ions and isotopes creation time: $(round(minimum(ion_benchmark.times) / 1000, digits=3)) μs")
@@ -117,7 +117,7 @@ bulk_benchmark = @benchmark begin
         Species("muon"), Species("pion0"), Species("photon"),
         Species("H"), Species("He"), Species("C"), Species("O"),
         Species("H+"), Species("He++"), Species("C+"),
-        Species("1H"), Species("12C"), Species("235U")
+        Species("#1H"), Species("#12C"), Species("#235U")
     ]
     
     # Access all properties

--- a/benchmark/detailed_benchmark.jl
+++ b/benchmark/detailed_benchmark.jl
@@ -118,7 +118,7 @@ species_types = [
     ("proton", Species("proton")),
     ("H", Species("H")),
     ("H+", Species("H+")),
-    ("12C", Species("12C"))
+    ("#12C", Species("#12C"))
 ]
 
 for (name, species) in species_types

--- a/benchmark/performance_test.jl
+++ b/benchmark/performance_test.jl
@@ -67,11 +67,11 @@ ion_benchmark = @benchmark begin
     he_plus_plus = Species("He++")
     c_plus = Species("C+")
     o_minus = Species("O-")
-    h1 = Species("1H")
-    c12 = Species("12C")
-    c13 = Species("13C")
-    u235 = Species("235U")
-    u238 = Species("238U")
+    h1 = Species("#1H")
+    c12 = Species("#12C")
+    c13 = Species("#13C")
+    u235 = Species("#235U")
+    u238 = Species("#238U")
 end
 
 println("   Ions and isotopes creation time: $(round(minimum(ion_benchmark.times) / 1000, digits=3)) μs")
@@ -116,7 +116,7 @@ bulk_benchmark = @benchmark begin
         Species("muon"), Species("pion0"), Species("photon"),
         Species("H"), Species("He"), Species("C"), Species("O"),
         Species("H+"), Species("He++"), Species("C+"),
-        Species("1H"), Species("12C"), Species("235U")
+        Species("#1H"), Species("#12C"), Species("#235U")
     ]
 
     # Access all properties

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -30,7 +30,7 @@ M_ELECTRON # 510998.95069  eV/c²
 e    = Species("electron")
 p    = Species("proton")
 h    = Species("H")          # neutral hydrogen, abundance-averaged mass
-he3  = Species("3He")        # neutral helium-3
+he3  = Species("#3He")       # neutral helium-3
 hion = Species("H+")         # singly-ionised hydrogen
 antip = Species("anti-proton")
 

--- a/examples/basic_usage.jl
+++ b/examples/basic_usage.jl
@@ -71,11 +71,11 @@ println()
 
 # 6. Create isotopes
 println("6. Isotopes:")
-h1 = Species("1H")
-c12 = Species("12C")
-c13 = Species("13C")
-u235 = Species("235U")
-u238 = Species("238U")
+h1 = Species("#1H")
+c12 = Species("#12C")
+c13 = Species("#13C")
+u235 = Species("#235U")
+u238 = Species("#238U")
 
 println("¹H: ", h1)
 println("¹²C: ", c12)

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -94,7 +94,7 @@ atomic species.
 massof(Species("electron"))              # 510998.95069  eV/c²
 massof(Species("proton"))               # 9.38272089430e8  eV/c²
 massof(Species("H"), AMU = true)        # ≈ 1.00794  u
-massof(Species("4He"), AMU = true)      # ≈ 4.0026  u
+massof(Species("#4He"), AMU = true)     # ≈ 4.0026  u
 ```
 """
 function massof(species::Species; AMU::Bool=false)
@@ -208,7 +208,7 @@ Return the mass number (isotope) of `species`.
 # Examples
 
 ```julia
-iso_of(Species("3He"))          # 3
+iso_of(Species("#3He"))         # 3
 iso_of(Species("He"))           # -1  (abundance average)
 iso_of(Species("electron"))     # 0
 ```

--- a/src/types.jl
+++ b/src/types.jl
@@ -28,9 +28,10 @@ Pass the openPMD name exactly:
 
 Atomic symbols `"H"` (Z=1) through `"Og"` (Z=118) are supported.
 
-**Mass number** — prefix the symbol with `#`-prefixed ASCII digits or
-Unicode superscripts. Omit for the abundance-averaged mass. A bare ASCII
-mass number (e.g. `"4He"`) is **not** accepted; the `#` is required.
+**Mass number** — There are two ways to include the mass number: Before the atomic symbol,
+either prefix with a pound symbol `#` followed by the mass number or, prefix with a 
+Unicode superscript(s). A bare ASCII mass number (e.g. `"4He"`) is **not** accepted.
+Correct would be `"#4He"` or `"⁴He"`.
 
 **Charge state** — append after the symbol. Repeated signs (`"++"`, `"---"`)
 or `"+n"` / `"-n"` notation are both accepted.

--- a/src/types.jl
+++ b/src/types.jl
@@ -28,16 +28,16 @@ Pass the openPMD name exactly:
 
 Atomic symbols `"H"` (Z=1) through `"Og"` (Z=118) are supported.
 
-**Mass number** — prefix the symbol with ASCII digits, `#`-prefixed digits, or
-Unicode superscripts. Omit for the abundance-averaged mass.
+**Mass number** — prefix the symbol with `#`-prefixed ASCII digits or
+Unicode superscripts. Omit for the abundance-averaged mass. A bare ASCII
+mass number (e.g. `"4He"`) is **not** accepted; the `#` is required.
 
 **Charge state** — append after the symbol. Repeated signs (`"++"`, `"---"`)
 or `"+n"` / `"-n"` notation are both accepted.
 
 ```julia
-Species("4He")      # helium-4, neutral
+Species("#4He")     # helium-4, neutral (# prefix required for ASCII digits)
 Species("⁴He")      # same, Unicode superscript
-Species("#4He")     # same, # prefix
 Species("Li+3")     # lithium, charge +3
 Species("Li+++")    # same
 Species("K-2")      # potassium, charge −2


### PR DESCRIPTION
## Summary

Several places in the docs and scripts showed bare-ASCII isotope names such as `"4He"` / `"3He"` as valid `Species` arguments, but the constructor rejects those — an ASCII mass number must be `#`-prefixed (`"#4He"`) or written with Unicode superscripts (`"⁴He"`).

This corrects the user-facing documentation and the runnable scripts that would otherwise error.

## Changes

- **`src/types.jl`** — `Species` docstring: mass-number wording now states the `#` is required and that a bare `"4He"` is not accepted; fixed the example block.
- **`src/functions.jl`** — `massof` and `iso_of` docstring examples (`"4He"` → `"#4He"`, `"3He"` → `"#3He"`).
- **`README.md`** — intro example and the "Mass Number Formatting" section, which had presented `"5He"` as a valid syntax; now shows the `#`-prefixed and Unicode-superscript forms.
- **`docs/src/index.md`** — overview example.
- **`examples/basic_usage.jl`, `benchmark/*`** — runnable scripts that would now error; bare forms like `"12C"` → `"#12C"`.
- **`Project.toml`** — version bump `0.11.2` → `0.11.3` so the corrected docstrings reach the registered package.

No behavior or API changes; docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)