### PR TITLE
Fix docs deployment and add PR doc previews

### DIFF
--- a/.github/workflows/DocPreviewCleanup.yml
+++ b/.github/workflows/DocPreviewCleanup.yml
@@ -1,0 +1,34 @@
+name: Doc Preview Cleanup
+
+on:
+  pull_request_target:
+    types: [closed]
+
+concurrency:
+  group: doc-preview-cleanup
+  cancel-in-progress: false
+
+jobs:
+  doc-preview-cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Delete the preview directory for this PR
+        env:
+          PR: ${{ github.event.number }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if [ -d "previews/PR$PR" ]; then
+            git rm -rf --quiet "previews/PR$PR"
+            git commit -m "delete preview for PR #$PR"
+            git push origin gh-pages
+          else
+            echo "No preview directory for PR #$PR; nothing to clean up."
+          fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,19 +5,29 @@ on:
   push:
     branches:
       - main
+    tags: ["*"]
   pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   docs:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write        # push to gh-pages
+      pull-requests: write   # post the preview link on the PR
+      statuses: write
     steps:
       - uses: actions/checkout@v4
 
       - uses: julia-actions/setup-julia@v2
         with:
           version: "1"
+
+      - uses: julia-actions/cache@v2
 
       - name: Install dependencies
         run: |
@@ -31,3 +41,28 @@ jobs:
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: julia --project=docs docs/make.jl
+
+      # Previews are only built for same-repo PRs: pull requests from forks get
+      # neither DOCUMENTER_KEY nor write access to gh-pages.
+      - name: Comment preview URL on the PR
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.number }}
+          URL: https://bmad-sim.github.io/AtomicAndPhysicalConstants.jl/previews/PR${{ github.event.number }}/
+        run: |
+          marker="<!-- docs-preview-link -->"
+          body="$marker
+          📖 Documentation preview for this PR: $URL
+
+          It is rebuilt on every push to this branch (allow a minute for GitHub Pages to publish) and removed when the PR is closed."
+
+          id=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments" --paginate \
+                 --jq "map(select(.body | startswith(\"$marker\"))) | .[0].id // empty")
+          if [ -n "$id" ]; then
+            gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$id" -f body="$body"
+          else
+            gh api -X POST "repos/$GITHUB_REPOSITORY/issues/$PR/comments" -f body="$body"
+          fi

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,7 +7,7 @@ makedocs(
     modules  = [AtomicAndPhysicalConstants],
     format   = Documenter.HTML(
         prettyurls       = get(ENV, "CI", nothing) == "true",
-        canonical        = "https://rot4te.github.io/AtomicAndPhysicalConstants.jl",
+        canonical        = "https://bmad-sim.github.io/AtomicAndPhysicalConstants.jl",
         assets           = String[],
     ),
     pages = [
@@ -24,8 +24,9 @@ makedocs(
 )
 
 deploydocs(
-    repo   = "github.com/rot4te/AtomicAndPhysicalConstants.jl",
+    repo   = "github.com/bmad-sim/AtomicAndPhysicalConstants.jl",
     target = "build",
     branch = "gh-pages",
     devbranch = "main",
+    push_preview = true,   # deploy PR builds to previews/PR##
 )


### PR DESCRIPTION
## Problem

`deploydocs` in `docs/make.jl` pointed at `github.com/rot4te/AtomicAndPhysicalConstants.jl`, but this repo is `bmad-sim/AtomicAndPhysicalConstants.jl`. Documenter compares the two and skips the push **without failing the job**, so the Documentation workflow has been reporting a green check while publishing nothing since it was added in #287 (2026-07-06):

```
┌ Info: Deployment criteria for deploying devbranch build from GitHub Actions:
│ - ✘ ENV["GITHUB_REPOSITORY"]="bmad-sim/AtomicAndPhysicalConstants.jl" occurs in repo="github.com/rot4te/AtomicAndPhysicalConstants.jl"
│ - ✔ ENV["GITHUB_EVENT_NAME"]="push" is "push", "workflow_dispatch" or "schedule"
│ - ✔ ENV["GITHUB_REF"] matches devbranch="main"
│ - ✔ ENV["GITHUB_ACTOR"] exists and is non-empty
│ - ✔ ENV["DOCUMENTER_KEY"] exists and is non-empty
└ Deploying: ✘
```

(from run 31829768309, the merge of #299)

`gh-pages` has been frozen at `build based on c0dea97` since 2026-03-05, so everything merged since then is missing from the published site.

## Changes

**`docs/make.jl`**
- `repo` and `canonical` now point at `bmad-sim`.
- `push_preview = true`, so PR builds deploy to `previews/PR##`.

**`.github/workflows/docs.yml`**
- Trigger on tags, so TagBot releases publish versioned docs and the `stable` link tracks the latest release.
- Add `concurrency` (cancel superseded PR builds), `julia-actions/cache@v2`, and `workflow_dispatch` for a manual re-publish.
- Post a sticky comment on the PR with the preview URL. Gated on the PR branch living in this repo — fork PRs get neither `DOCUMENTER_KEY` nor write access to `gh-pages`, so no preview is built and no misleading link is posted.

**`.github/workflows/DocPreviewCleanup.yml`** (new)
- Delete `previews/PR##` from `gh-pages` when a PR closes, so the branch does not accumulate stale builds.

## Verification

- Full doc build runs clean locally, doctests included.
- Re-ran `docs/make.jl` with the CI environment variables faked; all five deployment criteria now pass (`Deploying: ✔`).
- This PR is its own smoke test for the preview path: if the workflow posts a preview comment below and the link resolves, previews work.

## Needs a maintainer check

`DOCUMENTER_KEY` is present and non-empty, but since the deploy has never actually run under this workflow it is untested. If the key was generated for the `rot4te` fork, the first deploy will fail with a push permission error — regenerate with `DocumenterTools.genkeys()` and update both the repo secret and the deploy key.

GitHub Pages is confirmed serving `gh-pages` at `/` (legacy build), so `previews/` will be served.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
