### PR TITLE
Point the docs site root at dev

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -29,4 +29,9 @@ deploydocs(
     branch = "gh-pages",
     devbranch = "main",
     push_preview = true,   # deploy PR builds to previews/PR##
+    # Documenter redirects the site root to the first entry of `versions`, so
+    # putting "dev" first makes the landing page show the docs built from main.
+    # Doc fixes are then live on merge instead of waiting for the next release.
+    # The released versions stay available under stable/ and v#.# as usual.
+    versions = ["dev" => "dev", "stable" => "v^", "v#.#"],
 )


### PR DESCRIPTION
Follow-up to #301.

## What this does

Documenter redirects the `gh-pages` root to the **first entry** of the `versions` list, which defaulted to `"stable" => "v^"` — the newest release tag. So a documentation-only change merged to `main` was invisible at the landing page until the next release, and `stable` had been stuck on v0.9.0.

Putting `"dev"` first makes the root serve the docs built from `main`:

```julia
versions = ["dev" => "dev", "stable" => "v^", "v#.#"],
```

Released versions stay available under `stable/` and `v#.#`, and the version selector still lists all of them.

## Verified

Ran Documenter's `expand_versions` against a mock `gh-pages` tree containing the real version folders (`dev`, `v0.5.1` … `v0.11.4`):

| | default | this PR |
|---|---|---|
| root redirect | `./stable/` | `./dev/` |
| `DOC_VERSIONS[1]` | `stable` | `dev` |
| `DOCUMENTER_NEWEST` | `v0.11.4` | `dev` |
| `DOCUMENTER_STABLE` | `stable` | `dev` |
| `stable` symlink | `v0.11.4` | `v0.11.4` (unchanged) |

Full doc build runs clean locally, doctests included.

## Side effect worth knowing about

Documenter derives the redirect target *and* `DOCUMENTER_STABLE`/`DOCUMENTER_NEWEST` from the same list, so they cannot be set independently from `make.jl`. With `dev` first, `warner.js` treats every tagged version as outdated:

- Pages under `v0.11.4/` (and via the `stable/` symlink) get the "This documentation is for an older version" banner, linking to `/dev/`.
- Those pages also get a `noindex` meta tag, so search engines will index `dev` instead of the release docs.

That is coherent with the policy this PR adopts — `dev` is now the canonical documentation — but the banner wording is slightly off for the current release, which is not actually old. Two knobs if it turns out to be annoying:

1. `Documenter.HTML(warn_outdated = false)` removes the banner and the `noindex` everywhere, at the cost of losing the genuine "you are reading v0.5 docs" warning on old versions.
2. Revert this PR and instead commit a hand-written `index.html` to the `gh-pages` root. `generate_redirect_file` leaves any `index.html` alone that does not begin with its `<!--This file is automatically generated by Documenter.jl-->` marker, so that changes only the landing redirect and keeps all version semantics intact. The cost is a file living on `gh-pages` that is not visible anywhere in the source tree.

## Takes effect

On the next deploy — `index.html` and `versions.js` at the `gh-pages` root are regenerated by every build, including `dev` builds, so merging this is enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
